### PR TITLE
Cli updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ const nyc = require('name-your-contributors')
 
 nyc.repoContributors({
 	token: process.env.GITHUB_TOKEN,
-	user: 'RichardLitt',
+	user: 'mntnr,
 	repo: 'name-your-contributors'
 	}).then(//do something with the results
 	)
@@ -75,9 +75,67 @@ nyc.orgContributors({
 $ npm install -g name-your-contributors
 
 $ export GITHUB_TOKEN={your-token}
-$ name-your-contributors -u RichardLitt -r name-your-contributors
+
+$ name-your-contributors -u mntnr -r name-your-contributors
 
 $ name-your-contributors -o ipfs -a 2017-01-01 > ipfs-contrib.json
+```
+
+The output will be in the format:
+
+```sh
+$ name-your-contributors -u mntnr -r name-your-contributors --after 2017-11-10
+
+{
+  "commitAuthors": [],
+  "commitCommentators": [],
+  "prCreators": [],
+  "prCommentators": [
+	{
+	  "login": "RichardLitt",
+	  "name": "Richard Littauer",
+	  "url": "https://github.com/RichardLitt",
+	  "count": 3
+	},
+	{
+	  "login": "tgetgood",
+	  "name": "Thomas Getgood",
+	  "url": "https://github.com/tgetgood",
+	  "count": 2
+	}
+  ],
+  "issueCreators": [
+	{
+	  "login": "RichardLitt",
+	  "name": "Richard Littauer",
+	  "url": "https://github.com/RichardLitt",
+	  "count": 1
+	}
+  ],
+  "issueCommentators": [
+	{
+	  "login": "tgetgood",
+	  "name": "Thomas Getgood",
+	  "url": "https://github.com/tgetgood",
+	  "count": 1
+	},
+	{
+	  "login": "RichardLitt",
+	  "name": "Richard Littauer",
+	  "url": "https://github.com/RichardLitt",
+	  "count": 1
+	}
+  ],
+  "reactors": [
+	{
+	  "login": "patcon",
+	  "name": "Patrick Connolly",
+	  "url": "https://github.com/patcon",
+	  "count": 1
+	}
+  ],
+  "reviewers": []
+}
 ```
 
 ## API

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,7 +60,6 @@ const handleOut = console.log
 
 const handleError = e => {
   console.error(e.stack)
-
 }
 
 const callWithDefaults = (f, opts) => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,26 +1,8 @@
-#!/usr/bin/env node
+()#!/usr/bin/env node
 'use strict'
 
 const meow = require('meow')
-const csv = require('csv-writer').createArrayCsvStringifier
 const main = require('./index')
-
-const flatten = json => {
-  const prs = json.prCreators.map(x => ['pr creator'].concat(x))
-  const prcs = json.prCommentators.map(x => ['pr commentator'].concat(x))
-  const is = json.issueCreators.map(x => ['issue creator'].concat(x))
-  const iscs = json.issueCommentators.map(x => ['issue commentator'].concat(x))
-
-  return prs.concat(prcs).concat(is).concat(iscs)
-}
-
-const toCSV = json => {
-  const writer = csv({
-    header: ['TYPE', 'LOGIN', 'NAME']
-  })
-  return writer.getHeaderString() +
-    writer.stringifyRecords(flatten(json))
-}
 
 const cli = meow([`
   Usage
@@ -81,7 +63,7 @@ if (cli.flags.o && token) {
     after: after
   }).then(x => {
     if (cli.flags.csv) {
-      return toCSV(x)
+      return main.toCSV(x)
     } else {
       return JSON.stringify(x, null, 2)
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -33,7 +33,8 @@ const cli = meow([`
     r: 'repo',
     t: 'token',
     o: 'org',
-    u: 'user'
+    u: 'user',
+    v: 'verbose'
   }
 })
 
@@ -41,8 +42,6 @@ const token = cli.flags.t || process.env.GITHUB_TOKEN
 
 const after = cli.flags.a ? new Date(cli.flags.a) : new Date(0)
 const before = cli.flags.b ? new Date(cli.flags.b) : new Date()
-
-const debugMode = cli.flags.debug
 
 if (!token) {
   console.error('A token is needed to access the GitHub API. Please provide one with -t or the GITHUB_TOKEN environment variable.')
@@ -61,14 +60,16 @@ const handleOut = console.log
 
 const handleError = e => {
   console.error(e.stack)
-  process.exit(1)
+
 }
 
 const callWithDefaults = (f, opts) => {
   opts.before = before
   opts.after = after
   opts.token = token
-  opts.debug = debugMode
+  opts.debug = cli.flags.debug
+  opts.dryRun = cli.flags.dryRun
+  opts.verbose = cli.flags.v
 
   return f(opts).then(formatReturn).then(handleOut).catch(handleError)
 }
@@ -82,9 +83,6 @@ if (cli.flags.o) {
   fetchRepo(cli.flags.u, cli.flags.r)
 } else if (cli.flags.r) {
   main.currentUser(token).then(user => fetchRepo(user, cli.flags.r))
-} else if (cli.flags.u) {
-  console.error('-u alone is not currently supported. Rate limits make it infeasible')
-  // callWithDefaults(main.userContributors, {user: cli.flags.u})
 } else {
   main.getCurrentRepoInfo().then(({user, repo}) => fetchRepo(user, repo))
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,8 +56,10 @@ const cli = meow([`
 
 const token = cli.flags.t || process.env.GITHUB_TOKEN
 
+/* eslint-disable no-mixed-operators */
 const after = cli.flags.a && new Date(cli.flags.a) || new Date(0)
 const before = cli.flags.b && new Date(cli.flags.b) || new Date()
+/* eslint-enable no-mixed-operators */
 
 const debugMode = cli.flags.debug
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -56,10 +56,8 @@ const cli = meow([`
 
 const token = cli.flags.t || process.env.GITHUB_TOKEN
 
-/* eslint-disable no-mixed-operators */
-const after = cli.flags.a && new Date(cli.flags.a) || new Date(0)
-const before = cli.flags.b && new Date(cli.flags.b) || new Date()
-/* eslint-enable no-mixed-operators */
+const after = cli.flags.a ? new Date(cli.flags.a) : new Date(0)
+const before = cli.flags.b ? new Date(cli.flags.b) : new Date()
 
 const debugMode = cli.flags.debug
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -91,7 +91,15 @@ if (cli.flags.o) {
 } else if (cli.flags.r) {
   main.currentUser(token).then(user => fetchRepo(user, cli.flags.r))
 } else if (cli.flags.u) {
-
+  main.userContributors({
+    token,
+    user: cli.flags.u,
+    debug: debugMode,
+    before,
+    after
+  }).then(formatReturn)
+    .then(handleOut)
+    .catch(handleError)
 } else {
   main.getCurrentRepoInfo().then(({user, repo}) => fetchRepo(user, repo))
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -83,7 +83,8 @@ if (cli.flags.o) {
 } else if (cli.flags.r) {
   main.currentUser(token).then(user => fetchRepo(user, cli.flags.r))
 } else if (cli.flags.u) {
-  callWithDefaults(main.userContributors, {user: cli.flags.u})
+  console.error('-u alone is not currently supported. Rate limits make it infeasible')
+  // callWithDefaults(main.userContributors, {user: cli.flags.u})
 } else {
   main.getCurrentRepoInfo().then(({user, repo}) => fetchRepo(user, repo))
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const https = require('https')
-const fs = require('fs')
 
 /** Escape strings to prevent injection attacks. Other types aren't an issue. */
 const escapeArgValue = val => {

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -153,7 +153,7 @@ const executequery = ({token, query, debug, dryRun, verbose, name}) => {
     req.on('error', reject)
 
     if (debugMode) {
-      console.log('Query[' + name + ']: ' + JSON.stringify(runQ, null, 2))
+      console.log('Query[' + name + ']: ' + runQ)
     }
 
     req.write(runQ)

--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,17 @@ const orgContributors = ({token, orgName, before, after, debug}) =>
       graphql.executequery(token, queries.orgRepos(orgName, before, after), debug)
       .then(data => queries.cleanOrgRepos(token, data, before, after))
 
+/** Returns the login of the user to whom the given token is registered.
+  * @param token - GitHub Auth token
+  */
+const currentUser = token =>
+      graphql.executequery(token, queries.whoAmI)
+      .then(queries.cleanWhoAmI)
+
 module.exports = {
   toCSV,
   getCurrentRepoInfo,
+  currentUser,
   repoContributors,
   orgContributors,
   userRepoNames

--- a/src/index.js
+++ b/src/index.js
@@ -63,10 +63,15 @@ const repoContributors = ({token, user, repo, before, after, debug}) =>
       graphql.executequery(token, queries.repository(repo, user, before, after), debug)
       .then(json => queries.cleanRepo(token, json.repository, before, after))
 
-/** Returns a list of names of all repos belonging to user. */
-const userRepoNames = ({token, login, debug}) =>
-      graphql.executequery(token, queries.userRepos(login), debug)
-      .then(x => queries.cleanUserRepos(token, x))
+/** Returns contributions to all repos owned by user.
+  * @param token   - GitHub auth token
+  * @param user    - login of user
+  * @param before  - only return contributions before this timestamp
+  * @param after   - only return contributions after this timestamp
+  */
+const userContributors = ({token, user, debug, before, after}) =>
+      graphql.executequery(token, queries.userRepos(user, before, after), debug)
+      .then(x => queries.cleanUserRepos(token, x, before, after))
 
 /** Returns contributions to all repos owned by orgName.
   * @param token   - GitHub auth token
@@ -91,5 +96,5 @@ module.exports = {
   currentUser,
   repoContributors,
   orgContributors,
-  userRepoNames
+  userContributors
 }

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,15 @@ const toCSV = json => {
     writer.stringifyRecords(flatten(json))
 }
 
+const verifyResultHasKey = (key, query) =>
+      x => {
+        if (x[key] == null) {
+          throw new Error(`Bad query: ${key} '${query}' does not exist`)
+        } else {
+          return x
+        }
+      }
+
 //
 // API
 //
@@ -76,7 +85,8 @@ const repoContributors = (
         verbose,
         name: 'repoContributors',
         query: queries.repository(repo, user, before, after)
-      }).then(json => {
+      }).then(verifyResultHasKey('repository', user + '/' + repo))
+      .then(json => {
         if (dryRun) {
           return json
         } else {
@@ -98,7 +108,8 @@ const orgContributors = ({token, orgName, before, after, debug, dryRun, verbose}
         verbose,
         name: 'orgContributors',
         query: queries.orgRepos(orgName, before, after)
-      }).then(data => {
+      }).then(verifyResultHasKey('organization', orgName))
+      .then(data => {
         if (dryRun) {
           return data
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const parseGitURL = url => {
 
 const getCurrentRepoInfo = () => shellOut(gitConfigCommand)
       .then(parseGitURL)
-      .then(x => {return {user: x[1], repo: x[2]}})
+      .then(x => { return {user: x[1], repo: x[2]} })
 
 //
 // CSV Output
@@ -80,7 +80,7 @@ const repoContributors = (
         if (dryRun) {
           return json
         } else {
-          return queries.cleanRepo(token, json.repository, before, after)
+          return queries.cleanRepo(token, json.repository, before, after, verbose)
         }
       })
 
@@ -102,7 +102,7 @@ const orgContributors = ({token, orgName, before, after, debug, dryRun, verbose}
         if (dryRun) {
           return data
         } else {
-          return queries.cleanOrgRepos(token, data, before, after)
+          return queries.cleanOrgRepos(token, data, before, after, verbose)
         }
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,17 +21,19 @@ const shellOut = command =>
 
 const gitConfigCommand = 'git config --get remote.origin.url'
 
-const parseGitURL = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)$')
+const parseGitURLRE = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)$')
+
+const parseGitURL = url => {
+  const parse = parseGitURLRE.exec(url.trim())
+  if (parse[2].endsWith('.git')) {
+    parse[2] = parse[2].substr(0, parse[2].length - 4)
+  }
+  return parse
+}
 
 const getCurrentRepoInfo = () => shellOut(gitConfigCommand)
-      .then(x => parseGitURL.exec(x.trim()))
-      .then(x => {
-        let repo = x[2]
-        if (repo.endsWith('.git')) {
-          repo = repo.substr(0, repo.length - 4)
-        }
-        return {user: x[1], repo}
-      })
+      .then(parseGitURL)
+      .then(x => {return {user: x[1], repo: x[2]}})
 
 //
 // CSV Output
@@ -115,6 +117,7 @@ const currentUser = token =>
 
 module.exports = {
   toCSV,
+  parseGitURL,
   getCurrentRepoInfo,
   currentUser,
   repoContributors,

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,13 @@ const parseGitURL = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)\\n?$')
 
 const getCurrentRepoInfo = () => shellOut(gitConfigCommand)
       .then(x => parseGitURL.exec(x))
-      .then(x => { return {user: x[1], repo: x[2]} })
+      .then(x => {
+        let repo = x[2]
+        if (repo.endsWith('.git')) {
+          repo = repo.substr(0, repo.length - 4)
+        }
+        return {user: x[1], repo}
+      })
 
 //
 // CSV Output

--- a/src/index.js
+++ b/src/index.js
@@ -59,19 +59,22 @@ const toCSV = json => {
   * @param before - only return contributions before this timestamp
   * @param after  - only return contributions after this timestamp
   */
-const repoContributors = ({token, user, repo, before, after, debug}) =>
-      graphql.executequery(token, queries.repository(repo, user, before, after), debug)
-      .then(json => queries.cleanRepo(token, json.repository, before, after))
-
-/** Returns contributions to all repos owned by user.
-  * @param token   - GitHub auth token
-  * @param user    - login of user
-  * @param before  - only return contributions before this timestamp
-  * @param after   - only return contributions after this timestamp
-  */
-const userContributors = ({token, user, debug, before, after}) =>
-      graphql.executequery(token, queries.userRepos(user, before, after), debug)
-      .then(x => queries.cleanUserRepos(token, x, before, after))
+const repoContributors = (
+  {token, user, repo, before, after, debug, dryRun, verbose}) =>
+      graphql.executequery({
+        token,
+        debug,
+        dryRun,
+        verbose,
+        name: 'repoContributors',
+        query: queries.repository(repo, user, before, after)
+      }).then(json => {
+        if (dryRun) {
+          return json
+        } else {
+          return queries.cleanRepo(token, json.repository, before, after)
+        }
+      })
 
 /** Returns contributions to all repos owned by orgName.
   * @param token   - GitHub auth token
@@ -79,22 +82,35 @@ const userContributors = ({token, user, debug, before, after}) =>
   * @param before  - only return contributions before this timestamp
   * @param after   - only return contributions after this timestamp
   */
-const orgContributors = ({token, orgName, before, after, debug}) =>
-      graphql.executequery(token, queries.orgRepos(orgName, before, after), debug)
-      .then(data => queries.cleanOrgRepos(token, data, before, after))
+const orgContributors = ({token, orgName, before, after, debug, dryRun, verbose}) =>
+      graphql.executequery({
+        token,
+        debug,
+        dryRun,
+        verbose,
+        name: 'orgContributors',
+        query: queries.orgRepos(orgName, before, after)
+      }).then(data => {
+        if (dryRun) {
+          return data
+        } else {
+          return queries.cleanOrgRepos(token, data, before, after)
+        }
+      })
 
 /** Returns the login of the user to whom the given token is registered.
   * @param token - GitHub Auth token
   */
 const currentUser = token =>
-      graphql.executequery(token, queries.whoAmI)
-      .then(queries.cleanWhoAmI)
+      graphql.executequery({
+        token,
+        query: queries.whoAmI
+      }).then(queries.cleanWhoAmI)
 
 module.exports = {
   toCSV,
   getCurrentRepoInfo,
   currentUser,
   repoContributors,
-  orgContributors,
-  userContributors
+  orgContributors
 }

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,13 @@ const shellOut = command =>
                     }
                   }))
 
-const gitConfig = 'git config --get remote.origin.url'
+const gitConfigCommand = 'git config --get remote.origin.url'
 
 const parseGitURL = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)\\n?$')
 
-const current = shellOut(gitConfig).then(x => parseGitURL.exec(x))
+const getCurrentRepoInfo = () => shellOut(gitConfigCommand)
+      .then(x => parseGitURL.exec(x))
+      .then(x => { return {user: x[1], repo: x[2]} })
 
 //
 // CSV Output
@@ -78,6 +80,7 @@ const orgContributors = ({token, orgName, before, after, debug}) =>
 
 module.exports = {
   toCSV,
+  getCurrentRepoInfo,
   repoContributors,
   orgContributors,
   userRepoNames

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,10 @@ const shellOut = command =>
 
 const gitConfigCommand = 'git config --get remote.origin.url'
 
-const parseGitURL = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)\\n?$')
+const parseGitURL = new RegExp('.*github\\.com[:/]([^/]+)\\/(.+)$')
 
 const getCurrentRepoInfo = () => shellOut(gitConfigCommand)
-      .then(x => parseGitURL.exec(x))
+      .then(x => parseGitURL.exec(x.trim()))
       .then(x => {
         let repo = x[2]
         if (repo.endsWith('.git')) {

--- a/src/queries.js
+++ b/src/queries.js
@@ -70,16 +70,16 @@ const participantsQ = authoredWithReactionsQ
                 .addChild(pagination)
                 .addChild(authoredWithReactionsQ))
 
-const prsQ = node('pullRequests', {first: 100})
+const prsQ = node('pullRequests', {first: 50})
       .addChild(pagination)
       .addChild(participantsQ
                 .addChild(reviewQ))
 
-const issuesQ = node('issues', {first: 100})
+const issuesQ = node('issues', {first: 50})
       .addChild(pagination)
       .addChild(participantsQ)
 
-const commitCommentQ = node('commitComments', {first: 100})
+const commitCommentQ = node('commitComments', {first: 50})
       .addChild(pagination)
       .addChild(authoredQ)
 
@@ -92,15 +92,18 @@ const repository = (repoName, ownerName, before, after) =>
       .addChild(prsQ)
       .addChild(issuesQ)
 
+const repositoryCont = (before, after) =>
+      node('nodes')
+      .addChild(node('id'))
+      .addChild(commitCommentQ)
+      .addChild(refsQ(before, after))
+      .addChild(prsQ)
+      .addChild(issuesQ)
+
 const repositories = (before, after) =>
       node('repositories', {first: 5})
       .addChild(pagination)
-      .addChild(node('nodes')
-                .addChild(node('id'))
-                .addChild(commitCommentQ)
-                .addChild(refsQ(before, after))
-                .addChild(prsQ)
-                .addChild(issuesQ))
+      .addChild(repositoryCont(before, after))
 
 const orgRepos = (name, before, after) =>
       node('organization', {login: name})
@@ -351,7 +354,7 @@ const cleanOrgRepos = async (token, result, before, after) => {
     type: 'Organization',
     key: 'repositories',
     count: 20,
-    query: repositories(before, after)
+    query: repositoryCont(before, after)
   })
 
   return mergeRepoResults(
@@ -365,8 +368,8 @@ const cleanUserRepos = async (token, x, before, after) => {
     data: x.user,
     type: 'User',
     key: 'repositories',
-    count: 20,
-    query: repositories(before, after)
+    count: 5,
+    query: repositoryCont(before, after)
   })
 
   return mergeRepoResults(

--- a/src/queries.js
+++ b/src/queries.js
@@ -66,7 +66,7 @@ const reviewQ = node('reviews', {first: 20})
       .addChild(authoredQ)
 
 const participantsQ = authoredWithReactionsQ
-      .addChild(node('comments', {first: 100})
+      .addChild(node('comments', {first: 50})
                 .addChild(pagination)
                 .addChild(authoredWithReactionsQ))
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -70,10 +70,11 @@ const participantsQ = authoredWithReactionsQ
                 .addChild(pagination)
                 .addChild(authoredWithReactionsQ))
 
+const prsContQ = participantsQ.addChild(reviewQ)
+
 const prsQ = node('pullRequests', {first: 50})
       .addChild(pagination)
-      .addChild(participantsQ
-                .addChild(reviewQ))
+      .addChild(prsContQ)
 
 const issuesQ = node('issues', {first: 50})
       .addChild(pagination)
@@ -81,7 +82,7 @@ const issuesQ = node('issues', {first: 50})
 
 const commitCommentQ = node('commitComments', {first: 50})
       .addChild(pagination)
-      .addChild(authoredQ)
+      .addChild(authoredWithReactionsQ)
 
 /** Returns a query to retrieve all contributors to a repo */
 const repository = (repoName, ownerName, before, after) =>
@@ -251,7 +252,7 @@ const cleanRepo = async (token, result, before, after) => {
     type: 'Repository',
     key: 'pullRequests',
     count: 100,
-    query: participantsQ
+    query: prsContQ
   })
 
   const issues = await fetchAll({

--- a/src/queries.js
+++ b/src/queries.js
@@ -222,7 +222,7 @@ const cleanRepo = async (token, result, before, after) => {
 
   const branches = await fetchAll({
     token,
-    name: 'refsCont',
+    name: 'refs cont',
     acc: result.refs.nodes,
     data: result,
     type: 'Repository',
@@ -235,7 +235,7 @@ const cleanRepo = async (token, result, before, after) => {
 
   const commits = await depaginateAll(targets, {
     token,
-    name: 'commitsCont',
+    name: 'commits cont',
     acc: ref => ref.history.nodes,
     type: 'Commit',
     key: 'history',
@@ -382,22 +382,6 @@ const cleanOrgRepos = async (token, result, before, after) => {
     await Promise.all(repos.map(repo => cleanRepo(token, repo, before, after))))
 }
 
-const cleanUserRepos = async (token, x, before, after) => {
-  const repos = await fetchAll({
-    token,
-    name: 'user repos cont',
-    acc: x.user.repositories.nodes,
-    data: x.user,
-    type: 'User',
-    key: 'repositories',
-    count: 5,
-    query: repositoryCont(before, after)
-  })
-
-  return mergeRepoResults(
-    await Promise.all(repos.map(repo => cleanRepo(token, repo, before, after))))
-}
-
 const cleanWhoAmI = x => x.viewer.login
 
 module.exports = {
@@ -415,6 +399,5 @@ module.exports = {
   mergeRepoResults,
   authoredQ,
   userRepos,
-  cleanUserRepos,
   continuationQuery
 }

--- a/src/queries.js
+++ b/src/queries.js
@@ -7,6 +7,8 @@ const node = graphql.queryNode
 // Queries
 /// //
 
+const whoAmI = node('viewer').addChild(node('login'))
+
 const pagination = node('pageInfo')
       .addChild(node('endCursor'))
       .addChild(node('hasNextPage'))
@@ -378,7 +380,11 @@ const cleanOrgRepos = async (token, result, before, after) => {
     await Promise.all(repos.map(repo => cleanRepo(token, repo, before, after))))
 }
 
+const cleanWhoAmI = x => x.viewer.login
+
 module.exports = {
+  whoAmI,
+  cleanWhoAmI,
   repository,
   organization,
   orgRepos,

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -35,7 +35,7 @@ const contribPre = {
 test('No contributions in a single second', t => {
   return main.repoContributors({
     token: token,
-    user: 'RichardLitt',
+    user: 'mntnr',
     repo: 'name-your-contributors',
     after: new Date('2016-01-01T15:21:08.104Z'),
     before: new Date('2016-01-02T15:21:08.104Z')
@@ -63,7 +63,7 @@ const compareKeys = (x, k) =>
 test('Contributors before a fixed date remain static', t => {
   return main.repoContributors({
     token: token,
-    user: 'RichardLitt',
+    user: 'mntnr',
     repo: 'name-your-contributors',
     before: new Date('2017-09-21'),
     after: new Date(0)
@@ -77,17 +77,26 @@ test('Contributors before a fixed date remain static', t => {
 
 test('Queries without tokens get rejected', t => {
   return main.repoContributors({
-    user: 'RichardLitt',
+    user: 'mntnr',
     repo: 'name-your-contributors',
     before: new Date(),
     after: new Date(0)
   }).catch(error => t.is(error.message, 'Unauthorized'))
 })
 
-test('user repo names come back', async t => {
-  const repos = await main.userRepoNames({token, login: 'tgetgood'})
-
-  console.log(repos)
-
-  t.pass()
+test('All sorts of valid GitHub URLS', async t => {
+  /* eslint-disable */
+  // Need to test tabs...
+  const urls = [
+    'git@github.com:RichardLitt/name-your-contributors.git',
+    'git@github.com:RichardLitt/name-your-contributors\n',
+    '	https://github.com/RichardLitt/name-your-contributors ',
+    'https://github.com/RichardLitt/name-your-contributors	'
+  ]
+  /* eslint-enable */
+  for (let x of urls) {
+    let parse = main.parseGitURL(x)
+    t.is(parse[1], 'RichardLitt')
+    t.is(parse[2], 'name-your-contributors')
+  }
 })


### PR DESCRIPTION
You can now enter no args at the command line (except a token), in which case the current repo is queried, or just specify a repo in which case it is assumed to be yours.

I've disabled the isolated `--user` arg because with all of the new info being queried, this exceeds the rate limit when querying myself. I'm not especially profuse, so it's likely that this will just fail for most users. 

The logic is still there if we can optimise the queries or think of another way to do it.

Addresses #26 