### PR TITLE
refactor: rearranged query order.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,14 @@ $ export GITHUB_TOKEN=ab34e...
 You can also set the var automatically in every session by adding the above line
 to your `.bashrc` file in your home directory.
 
+The cost of querying a repo is approximately the number of PRs + the number of
+issues + the number of comments with reactions (if querying reactions) + the
+number of commits / 100 (if querying commit log).
+
+So in the simplest case it's simply the total number of issues and PRs in the
+repos being queried.
+
+
 #### Caveats
 
 GitHub regulates API traffic by a credit system. The limits are quite high; it's

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -44,6 +44,9 @@ const childrenString = children => {
 }
 
 itemToString = ({name, args, children}) => {
+  if (args == null) {
+    throw new Error(`No args passed to ${name}`)
+  }
   return name + argsString(args) + childrenString(children)
 }
 


### PR DESCRIPTION
Reduced average query cost by a factor of 2-4. Much more in some extreme cases. Query costs are actually more predictable now as well. Added a guestimate formula to the README.

First step in #52. I think this is useful enough in and of itself to merge in.

Note: there are no API changes in this PR.