### PR TITLE
Query less by default

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -65,8 +65,8 @@ const defaultOpts = opts => {
   opts.debug = cli.flags.debug
   opts.dryRun = cli.flags.dryRun
   opts.verbose = cli.flags.v
-  opts.commits = cli.flags.commits
-  opts.reactions = !cli.flags.localDir && cli.flags.reactions
+  opts.commits = !cli.flags.localDir && cli.flags.commits
+  opts.reactions = cli.flags.reactions
 
   return opts
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,15 +9,26 @@ const cli = meow([`
     $ name-your-contributors <input> [opts]
 
   Options
-    -a, --after  - Get contributions after date
-    -b, --before - Get contributions before data
-    --csv        - Output data in CSV format
-    -o, --org    - Search all repos within this organisation
-    -r, --repo   - Repository to search
-    -t, --token  - GitHub auth token to use
-    -u, --user   - User to which repository belongs
-    -c, --config - Operate from config file. In this mode only token, verbose, and
-                   debug flags apply.
+    -t, --token   - GitHub auth token to use
+    -a, --after   - Get contributions after date
+    -b, --before  - Get contributions before data
+
+    -o, --org     - Search all repos within this organisation
+    -r, --repo    - Repository to search
+    -u, --user    - User to which repository belongs
+    -c, --config  - Operate from config file. In this mode only token, verbose, and
+                    debug flags apply.
+
+    --csv         - Output data in CSV format
+
+    --commits     - Get commit authors and comments from GitHub
+    --local-dir   - If specified, this script will look for repos being queried in
+                    the provided dir and read the commit log from them directly.
+    --reactions   - Query reactions of comments as well.
+
+    -v, --verbose - Enable verbose logging
+    --debug       - Enable extremely verbose logging
+    --dry-run     - Check the cost of the query without executing it.
 
   Authentication
     This script looks for an auth token in the env var GITHUB_TOKEN. Make sure

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -88,6 +88,7 @@ const formatQuery = item => '{"query": ' +
 
 // Global debug mode.
 let debugMode = false
+let reqCounter = 1
 
 /**
   * Returns a promise which will yeild a query result.
@@ -131,7 +132,8 @@ const executequery = ({token, query, debug, dryRun, verbose, name}) => {
                             JSON.stringify(json.data, null, 2))
               }
               if (verbose) {
-                console.log('Cost of[' + name + ']: ' +
+                console.log('Cost of[' + name + ']: (' +
+                            '#' + reqCounter++ + ') ' +
                             JSON.stringify(json.data.rateLimit))
               }
 

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const repoContributors = ({
   dryRun,
   verbose,
   name: `repoContributors: ${user}/${repo}`,
-  query: queries.repository(repo, user, before, after)
+  query: queries.repository(repo, user, before, after, commits)
 }).then(verifyResultHasKey('repository', user + '/' + repo, dryRun))
       .then(json => {
         if (dryRun) {
@@ -119,16 +119,16 @@ const orgContributors = ({
   debug,
   dryRun,
   verbose,
-  commits,
-  reactions,
   name: `orgContributors: ${orgName}`,
-  query: queries.orgRepos(orgName, before, after)
+  query: queries.orgRepos(orgName, before, after, commits)
 }).then(verifyResultHasKey('organization', orgName, dryRun))
       .then(data => {
         if (dryRun) {
           return data
         } else {
-          return queries.cleanOrgRepos(token, data, before, after, verbose)
+          return queries.cleanOrgRepos({
+            token, result: data, before, after, verbose, commits, reactions
+          })
         }
       })
 


### PR DESCRIPTION
I've made querying commits and reactions opt in with flags for each.

With the query refactoring from #56 reactions don't seem to be very expensive anymore since we only need to make one query per comment with more than one reaction. Of course that will get expensive again in a very socially active repo.

