### PR TITLE
Scraping Ettiquette

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -84,10 +84,14 @@ const formatReturn = x => {
   }
 }
 
-const handleOut = console.log
+const handleOut = res => {
+  console.log(res)
+  process.exit(0)
+}
 
 const handleError = e => {
   console.error(e.stack)
+  process.exit(0)
 }
 
 const handle = (f, opts) =>

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -168,10 +168,8 @@ let lastMinute = 0
 let warned = false
 
 // Rate limit parameters
-// We actually wait a minute after the request comes back before allowing the
-// next one to run
-const maxConnections = 20
-const maxPerMinute = 100
+const maxConnections = 1
+const maxPerMinute = 300
 
 const allocate = (args, verbose, debug) => {
   if (debug) {
@@ -189,10 +187,10 @@ const allocate = (args, verbose, debug) => {
         warned = true
         console.log('Warning!!! Rate throttling has taken effect. This query might take awhile; go grab some coffee.')
       }
-      if (verbose && !debug && running > 0) {
+      if (verbose && !debug && lastMinute >= maxPerMinute) {
         console.log(`Throttled!! Running: ${running}, lastMinute: ${lastMinute}`)
       }
-      setTimeout(() => resolve(allocate(args)), 1000)
+      setTimeout(() => resolve(allocate(args, verbose, debug)), 1000)
     }
   })
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -88,13 +88,12 @@ const formatQuery = item => '{"query": ' +
 
 // Global debug mode.
 let debugMode = false
-let reqCounter = 1
 
 /** Inner query executor.
 
     Same params and output as executequery
   */
-const executequeryRaw = ({token, query, debug, dryRun, verbose, name}) => {
+const queryRequest = ({token, query, debug, dryRun, verbose, name}) => {
   if (debug) {
     debugMode = true
   }
@@ -120,22 +119,7 @@ const executequeryRaw = ({token, query, debug, dryRun, verbose, name}) => {
         })
         res.on('end', () => {
           if (res.statusCode === 200) {
-            const json = JSON.parse(queryResponse)
-            if (json.data) {
-              if (debugMode) {
-                console.log('Result of[' + name + ']: ' +
-                            JSON.stringify(json.data, null, 2))
-              }
-              if (verbose) {
-                console.log('Cost of[' + name + ']: (' +
-                            '#' + reqCounter++ + ') ' +
-                            JSON.stringify(json.data.rateLimit))
-              }
-
-              resolve(json.data)
-            } else {
-              reject(new Error('Graphql error: ' + JSON.stringify(json, null, 2)))
-            }
+            resolve(queryResponse)
           } else {
             console.error({
               statusCode: res.statusCode,
@@ -160,49 +144,64 @@ const executequeryRaw = ({token, query, debug, dryRun, verbose, name}) => {
   })
 }
 
-// Global connection
-let running = 0
+// Number requests for reference.
+let reqCounter = 1
+
+const parseResponse = (queryResponse, queryName, verbose = false) => {
+  const json = JSON.parse(queryResponse)
+  if (json.data) {
+    if (debugMode) {
+      console.log('Result of[' + queryName + ']: ' +
+                  JSON.stringify(json.data, null, 2))
+    }
+    if (verbose) {
+      console.log('Cost of[' + queryName + ']: (' +
+                  '#' + reqCounter++ + ') ' +
+                  JSON.stringify(json.data.rateLimit))
+    }
+
+    return json.data
+  } else {
+    throw new Error('Graphql error: ' + JSON.stringify(json, null, 2))
+  }
+}
+
+let running = false
+
 let lastMinute = 0
-
-// Warning about rate throttling
-let warned = false
-
-// Rate limit parameters
-const maxConnections = 1
 const maxPerMinute = 300
 
-const allocate = (args, verbose, debug) => {
-  if (debug) {
-    if (running > 0) {
-      console.log(`Running: ${running}, lastMinute: ${lastMinute}`)
+const queue = []
+
+const runQueue = () => {
+  if (running) {
+    // noop
+  } else if (lastMinute >= maxPerMinute) {
+    setTimeout(runQueue, 1000)
+  } else {
+    if (queue.length > 0) {
+      running = true
+      lastMinute++
+      setTimeout(() => lastMinute--, 60000)
+
+      const {args, resolve} = queue.shift()
+      const res = queryRequest(args)
+
+      res.then(x => {
+        process.nextTick(runQueue)
+        running = false
+      })
+
+      resolve(res.then(x => parseResponse(x, args.name, args.verbose)))
     }
   }
-  return new Promise((resolve, reject) => {
-    if (running < maxConnections && lastMinute < maxPerMinute) {
-      running++
-      lastMinute++
-      resolve(executequeryRaw(args))
-    } else {
-      if (!warned && lastMinute >= maxPerMinute) {
-        warned = true
-        console.log('Warning!!! Rate throttling has taken effect. This query might take awhile; go grab some coffee.')
-      }
-      if (verbose && !debug && lastMinute >= maxPerMinute) {
-        console.log(`Throttled!! Running: ${running}, lastMinute: ${lastMinute}`)
-      }
-      setTimeout(() => resolve(allocate(args, verbose, debug)), 1000)
-    }
-  })
 }
 
-const finished = () => {
-  running--
-}
-
-const free = res => {
-  setTimeout(() => lastMinute--, 60000)
-  res.then(finished).catch(finished)
-}
+const executeOnQueue = args =>
+      new Promise((resolve, reject) => {
+        queue.push({args, resolve, reject})
+        runQueue()
+      })
 
 /**
   * Returns a promise which will yeild a query result.
@@ -213,11 +212,7 @@ const free = res => {
   * @param {bool}      debug   - Debug mode: VERY verbose logging.
   * @param {bool}      dryRun  - Execute a dry run, check query but don't run.
   */
-const executequery = args => {
-  const response = allocate(args, args.verbose, args.debug)
-  free(response)
-  return response
-}
+const executequery = args => executeOnQueue(args)
 
 module.exports = {
   executequery,

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -78,7 +78,7 @@ const queryNode = (name, args = {}, children = []) => {
   */
 const queryCost = (item, dryRun) => '{"query": ' +
       JSON.stringify(
-        `query{rateLimit(dryRun: ${Boolean(dryRun)}){cost, remaining}\n` +
+        `query{rateLimit(dryRun: ${Boolean(dryRun)}){cost, remaining, resetAt}\n` +
           item.toString() + '}') + '}'
 
 /** Converts a queryNode object into a valid graphql query string according to
@@ -90,16 +90,11 @@ const formatQuery = item => '{"query": ' +
 let debugMode = false
 let reqCounter = 1
 
-/**
-  * Returns a promise which will yeild a query result.
-  * @param {string}    token   - Github auth token.
-  * @param {queryNode} query   - The query to execute.
-  * @param {string}    name    - Name of this query. For debugging only.
-  * @param {bool}      verbose - Enable verbose logging.
-  * @param {bool}      debug   - Debug mode: VERY verbose logging.
-  * @param {bool}      dryRun  - Execute a dry run, check query but don't run.
+/** Inner query executor.
+
+    Same params and output as executequery
   */
-const executequery = ({token, query, debug, dryRun, verbose, name}) => {
+const executequeryRaw = ({token, query, debug, dryRun, verbose, name}) => {
   if (debug) {
     debugMode = true
   }
@@ -163,6 +158,67 @@ const executequery = ({token, query, debug, dryRun, verbose, name}) => {
     req.write(runQ)
     req.end()
   })
+}
+
+// Global connection
+let running = 0
+let lastMinute = 0
+
+// Warning about rate throttling
+let warned = false
+
+// Rate limit parameters
+// We actually wait a minute after the request comes back before allowing the
+// next one to run
+const maxConnections = 20
+const maxPerMinute = 100
+
+const allocate = (args, verbose, debug) => {
+  if (debug) {
+    if (running > 0) {
+      console.log(`Running: ${running}, lastMinute: ${lastMinute}`)
+    }
+  }
+  return new Promise((resolve, reject) => {
+    if (running < maxConnections && lastMinute < maxPerMinute) {
+      running++
+      lastMinute++
+      resolve(executequeryRaw(args))
+    } else {
+      if (!warned && lastMinute >= maxPerMinute) {
+        warned = true
+        console.log('Warning!!! Rate throttling has taken effect. This query might take awhile; go grab some coffee.')
+      }
+      if (verbose && !debug && running > 0) {
+        console.log(`Throttled!! Running: ${running}, lastMinute: ${lastMinute}`)
+      }
+      setTimeout(() => resolve(allocate(args)), 1000)
+    }
+  })
+}
+
+const finished = () => {
+  running--
+}
+
+const free = res => {
+  setTimeout(() => lastMinute--, 60000)
+  res.then(finished).catch(finished)
+}
+
+/**
+  * Returns a promise which will yeild a query result.
+  * @param {string}    token   - Github auth token.
+  * @param {queryNode} query   - The query to execute.
+  * @param {string}    name    - Name of this query. For debugging only.
+  * @param {bool}      verbose - Enable verbose logging.
+  * @param {bool}      debug   - Debug mode: VERY verbose logging.
+  * @param {bool}      dryRun  - Execute a dry run, check query but don't run.
+  */
+const executequery = args => {
+  const response = allocate(args, args.verbose, args.debug)
+  free(response)
+  return response
 }
 
 module.exports = {

--- a/src/queries.js
+++ b/src/queries.js
@@ -387,7 +387,7 @@ const cleanRepo = async ({
       token,
       name: 'pr comment reactions cont',
       acc: prc => prc.reactions.nodes,
-      type: 'PullRequestComment',
+      type: 'IssueComment',
       key: 'reactions',
       query: reactorSubQ
     })).concat(await depaginateAll(issues, {

--- a/src/queries.js
+++ b/src/queries.js
@@ -284,7 +284,7 @@ const cleanRepo = async ({
       count: 100,
       query: commitQ(before, after)
     })
-    }
+  }
 
   const targets = Array.from(branches).map(b => b.target)
 


### PR DESCRIPTION
After some back and forth with support, it seems that we can only make on request at a time. No parallelism. Also no more than 300 requests a minute.

After meeting these constraints, the script is somewhat slower, but does not seem to get blocked.

We can now make requests until the quota runs out without getting banned. It does take a few minutes, but that seems to be unavoidable if we want to play by GitHub's rules.