### PR TITLE
Traceability Enhancements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ token removed and a `contributions` key added to each object, like so:
 	"after": "2017-06-01",
 	"contributions" : {
 	  "commitAuthors": [...],
-	  "commitCommentators: [...],
+	  "commitCommentators": [...],
 	  ,,,
 	},
 	...

--- a/readme.md
+++ b/readme.md
@@ -235,6 +235,22 @@ Type: `string`
 
 Only traverse the given repository.
 
+## Development
+
+There are several extra flags that are useful for development and diagnosing
+issues:
+
+`-v, --verbose` prints out each query that is sent to the api along with its
+cost and the quota remaining after it is run.
+
+`--debug` prints out each query sent to the server and the raw response. This is
+extremely verbose.
+
+`--dry-run` prints the cost of the first query that would have been run *without
+running it*. Note that since the query isn't executed, follow up queries aren't
+possible. when used with the `-c, --config` option, dry runs the first query for
+each entry of the config file.
+
 ## License
 
 MIT © [Richard Littauer](http://burntfen.com)

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,14 @@ $ export GITHUB_TOKEN=ab34e...
 You can also set the var automatically in every session by adding the above line
 to your `.bashrc` file in your home directory.
 
+The cost of querying a repo is approximately the number of PRs + the number of
+issues + the number of comments with reactions (if querying reactions) + the
+number of commits / 100 (if querying commit log).
+
+So in the simplest case it's simply the total number of issues and PRs in the
+repos being queried.
+
+
 #### Caveats
 
 GitHub regulates API traffic by a credit system. The limits are quite high; it's

--- a/readme.md
+++ b/readme.md
@@ -197,6 +197,90 @@ $ name-your-contributors -u mntnr -r name-your-contributors --after 2017-11-10
 }
 ```
 
+### Result formats
+
+Name Your Contributors offers 4 distinct result formats intended for different
+consumers.
+
+#### Default
+
+The default result format is an aggregate synopsis of all contributions in the
+given time window. This is the format in the examples above.
+
+#### CSV
+
+With the `--csv` flag provided at the command line, nyc will return the default
+info in CSV format rather than JSON.
+
+#### Full Contribution Tree
+
+If the `--full` flag is passed at the command line, then nyc will return the
+full tree of org->repo->pr->comment->reaction->author for all interactions in
+the given time window. This format is quite verbose, but invaluable if you want
+to know not only who contributed, but the details of every contribution made.
+
+For example,
+```sh
+$ name-your-contributors -r name-your-contributors -u mntnr -b 2017-12-10 -a 2017-11-10 --full
+```
+will return (abbreviated):
+```sh
+{
+  "repository": {
+	"homepageUrl": "",
+	"name": "name-your-contributors",
+	"owner": {
+	  "login": "mntnr"
+	},
+	"pullRequests": [
+	  {
+		"title": "Cli updates",
+		"number": 43,
+		"state": "MERGED",
+		"author": {
+		  "login": "tgetgood",
+		  "name": "Thomas Getgood",
+		  "url": "https://github.com/tgetgood"
+		},
+		"createdAt": "2017-10-26T19:48:39Z",
+		"comments": [
+		  {
+			"author": {
+			  "login": "RichardLitt",
+			  "name": "Richard Littauer",
+			  "url": "https://github.com/RichardLitt"
+			},
+			"createdAt": "2017-11-20T16:35:31Z"
+		  },
+		  {
+			"author": {
+			  "login": "tgetgood",
+			  "name": "Thomas Getgood",
+			  "url": "https://github.com/tgetgood"
+			},
+			"createdAt": "2017-11-21T21:05:15Z"
+		  },
+		  ...
+		],
+		"reviews": []
+	  },
+	  ...
+	]
+  }
+}
+```
+
+Notice that the pull request above was created before the date passed to
+before. It is still included because comments made within it were created in the
+desired timeframe. If there had been no such comments, the PR would not be
+included.
+
+#### Condensed
+
+For an even more condensed output format which also allows filtering on given
+users, see the postprocessing script
+[Who Did What](https://github.com/mntnr/whodidwhat).
+
 ## API
 
 ### orgContributors({orgName, token, before, after})

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@
 
 const meow = require('meow')
 const main = require('./index')
+const done = require('./graphql').done
 
 const cli = meow([`
   Usage
@@ -84,14 +85,23 @@ const formatReturn = x => {
   }
 }
 
+const cleanup = () => {
+  if (done()) {
+    process.exit(0)
+  } else {
+    setTimeout(cleanup, 1000)
+  }
+}
+
+
 const handleOut = res => {
   console.log(res)
-  process.exit(0)
+  cleanup()
 }
 
 const handleError = e => {
   console.error(e.stack)
-  process.exit(0)
+  process.exit(1)
 }
 
 const handle = (f, opts) =>

--- a/src/cli.js
+++ b/src/cli.js
@@ -11,12 +11,12 @@ const cli = meow([`
   Options
     -a, --after  - Get contributions after date
     -b, --before - Get contributions before data
-    -c, --csv    - Output data in CSV format
+    --csv        - Output data in CSV format
     -o, --org    - Search all repos within this organisation
     -r, --repo   - Repository to search
     -t, --token  - GitHub auth token to use
     -u, --user   - User to which repository belongs
-    --config     - Operate from config file. In this mode only token, verbose, and
+    -c, --config - Operate from config file. In this mode only token, verbose, and
                    debug flags apply.
 
   Authentication
@@ -33,7 +33,7 @@ const cli = meow([`
   alias: {
     a: 'after',
     b: 'before',
-    c: 'csv',
+    c: 'config',
     r: 'repo',
     t: 'token',
     o: 'org',
@@ -47,7 +47,7 @@ const token = cli.flags.t || process.env.GITHUB_TOKEN
 const after = cli.flags.a ? new Date(cli.flags.a) : new Date(0)
 const before = cli.flags.b ? new Date(cli.flags.b) : new Date()
 
-if (!token && !cli.flags.config) {
+if (!token && !cli.flags.c) {
   console.error('A token is needed to access the GitHub API. Please provide one with -t or the GITHUB_TOKEN environment variable.')
   process.exit(1)
 }
@@ -80,9 +80,9 @@ const callWithDefaults = (f, opts) => {
 const fetchRepo = (user, repo) =>
       callWithDefaults(main.repoContributors, {user, repo})
 
-if (cli.flags.config) {
+if (cli.flags.c) {
   main.fromConfig({
-    file: cli.flags.config,
+    file: cli.flags.c,
     token,
     verbose: cli.flags.v,
     debug: cli.flags.debug,

--- a/src/cli.js
+++ b/src/cli.js
@@ -93,9 +93,10 @@ const formatReturn = x => {
   }
 }
 
-const cleanup = () => {
+/** Wait for outstanding requests to resolve and shut down the program. */
+const cleanup = ret => {
   if (done()) {
-    process.exit(0)
+    process.exit(ret)
   } else {
     setTimeout(cleanup, 1000)
   }
@@ -103,12 +104,12 @@ const cleanup = () => {
 
 const handleOut = res => {
   console.log(res)
-  cleanup()
+  cleanup(0)
 }
 
 const handleError = e => {
   console.error(e.stack)
-  process.exit(1)
+  cleanup(1)
 }
 
 const handle = (f, opts) =>

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,6 +20,8 @@ const cli = meow([`
     -c, --config  - Operate from config file. In this mode only token, verbose, and
                     debug flags apply.
 
+    --full        - Returns the full tree of contributions rather than the default
+                    synopsis.
     --csv         - Output data in CSV format
 
     --commits     - Get commit authors and comments from GitHub
@@ -68,12 +70,18 @@ const defaultOpts = opts => {
   opts.verbose = cli.flags.v
   opts.commits = !cli.flags.localDir && cli.flags.commits
   opts.reactions = cli.flags.reactions
+  opts.full = cli.flags.full
 
   return opts
 }
 
 if (!token && !cli.flags.c) {
   console.error('A token is needed to access the GitHub API. Please provide one with -t or the GITHUB_TOKEN environment variable.')
+  process.exit(1)
+}
+
+if (cli.flags.full && cli.flags.csv) {
+  console.error('Cannot format full tree output as CSV.')
   process.exit(1)
 }
 
@@ -92,7 +100,6 @@ const cleanup = () => {
     setTimeout(cleanup, 1000)
   }
 }
-
 
 const handleOut = res => {
   console.log(res)

--- a/src/cli.js
+++ b/src/cli.js
@@ -65,8 +65,8 @@ const defaultOpts = opts => {
   opts.debug = cli.flags.debug
   opts.dryRun = cli.flags.dryRun
   opts.verbose = cli.flags.v
-  opts.commits = cli.flags.commits
-  opts.reactions = !cli.flags.localDir && cli.flags.reactions
+  opts.commits = !cli.flags.localDir && cli.flags.commits
+  opts.reactions = cli.flags.reactions
 
   return opts
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,15 +9,26 @@ const cli = meow([`
     $ name-your-contributors <input> [opts]
 
   Options
-    -a, --after  - Get contributions after date
-    -b, --before - Get contributions before data
-    --csv        - Output data in CSV format
-    -o, --org    - Search all repos within this organisation
-    -r, --repo   - Repository to search
-    -t, --token  - GitHub auth token to use
-    -u, --user   - User to which repository belongs
-    -c, --config - Operate from config file. In this mode only token, verbose, and
-                   debug flags apply.
+    -t, --token   - GitHub auth token to use
+    -a, --after   - Get contributions after date
+    -b, --before  - Get contributions before data
+
+    -o, --org     - Search all repos within this organisation
+    -r, --repo    - Repository to search
+    -u, --user    - User to which repository belongs
+    -c, --config  - Operate from config file. In this mode only token, verbose, and
+                    debug flags apply.
+
+    --csv         - Output data in CSV format
+
+    --commits     - Get commit authors and comments from GitHub
+    --local-dir   - If specified, this script will look for repos being queried in
+                    the provided dir and read the commit log from them directly.
+    --reactions   - Query reactions of comments as well.
+
+    -v, --verbose - Enable verbose logging
+    --debug       - Enable extremely verbose logging
+    --dry-run     - Check the cost of the query without executing it.
 
   Authentication
     This script looks for an auth token in the env var GITHUB_TOKEN. Make sure

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -88,6 +88,7 @@ const formatQuery = item => '{"query": ' +
 
 // Global debug mode.
 let debugMode = false
+let reqCounter = 1
 
 /**
   * Returns a promise which will yeild a query result.
@@ -131,7 +132,8 @@ const executequery = ({token, query, debug, dryRun, verbose, name}) => {
                             JSON.stringify(json.data, null, 2))
               }
               if (verbose) {
-                console.log('Cost of[' + name + ']: ' +
+                console.log('Cost of[' + name + ']: (' +
+                            '#' + reqCounter++ + ') ' +
                             JSON.stringify(json.data.rateLimit))
               }
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -109,8 +109,13 @@ const queryEdge = (name, args, children) => {
   }).addChild(queryNode('nodes', {}, children))
 }
 
-const queryOn = (type, children) =>
-      queryNode(`... on ${type}`, {}, children)
+const queryOn = (type, children) => queryRoot({
+  name: `... on ${type}`,
+  args: {},
+  children,
+  type: 'on',
+  nodeType: type
+})
 
 const queryType = (name, args, types) => {
   const children = types.map(([type, children]) => queryOn(type, children))
@@ -235,10 +240,12 @@ const cleanwalk = (json, query) => {
       delete node.__typename
       cleanChildren(node, children)
     })
-  } else if (type === 'type') {
+  } else if (type === 'typed') {
     delete json[name].id
     delete json[name].__typename
-    cleanChildren(json[name], query.children[0].children)
+    for (const child of query.children) {
+      cleanChildren(json[name], child.children)
+    }
   } else if (type === 'node') {
     delete json[name].id
     delete json[name].__typename

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -189,19 +189,21 @@ const queryRequest = ({token, query, debug, dryRun, verbose, name}) => {
 // Number requests for reference.
 let reqCounter = 1
 
-const parseResponse = (queryResponse, queryName, verbose, debug) => {
+const logResponse = (queryName, verbose, debug) => json => {
+  if (debug) {
+    console.log(`#${reqCounter++} [${queryName}]: \
+${JSON.stringify(json, null, 2)}`)
+  } else if (verbose) {
+    console.log(`#${reqCounter++} [${queryName}]:
+ ${JSON.stringify(json.rateLimit)}`)
+  }
+
+  return json
+}
+
+const parseResponse = queryResponse => {
   const json = JSON.parse(queryResponse)
   if (json.data) {
-    if (debug) {
-      console.log('Result of[' + queryName + ']: ' +
-                  JSON.stringify(json.data, null, 2))
-    }
-    if (verbose) {
-      console.log('Cost of[' + queryName + ']: (' +
-                  '#' + reqCounter++ + ') ' +
-                  JSON.stringify(json.data.rateLimit))
-    }
-
     return json.data
   } else {
     throw new Error('Graphql error: ' + JSON.stringify(json, null, 2))
@@ -234,7 +236,8 @@ const runQueue = () => {
         running = false
       })
 
-      resolve(req.then(x => parseResponse(x, args.name, args.verbose, args.debug)))
+      resolve(req.then(parseResponse)
+              .then(logResponse(args.name, args.verbose, args.debug)))
     }
   }
 }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -44,6 +44,9 @@ const childrenString = children => {
 }
 
 itemToString = ({name, args, children}) => {
+  if (args == null) {
+    throw new Error(`No args passed to ${name}`)
+  }
   return name + argsString(args) + childrenString(children)
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,9 @@ const verifyResultHasKey = (key, query, dryRun) =>
 // API
 //
 
+const prunedFetch = args => graphql.prune(args)
+      .then(json => queries.timeFilterFullTree(json, args.before, args.after))
+
 /** Returns all contributions to a repo.
   * @param token  - GitHub auth token
   * @param user   - Username to whom the repo belongs
@@ -94,7 +97,7 @@ const repoContributors = ({
           }
         })
 
-  const qfn = full ? graphql.prune : summarize
+  const qfn = full ? prunedFetch : summarize
 
   return qfn({
     token,
@@ -128,7 +131,7 @@ const orgContributors = ({
           }
         })
 
-  const qfn = full ? graphql.prune : summarise
+  const qfn = full ? prunedFetch : summarise
 
   return qfn({
     token,

--- a/src/index.js
+++ b/src/index.js
@@ -57,9 +57,9 @@ const toCSV = json => {
     writer.stringifyRecords(flatten(json))
 }
 
-const verifyResultHasKey = (key, query) =>
+const verifyResultHasKey = (key, query, dryRun) =>
       x => {
-        if (x[key] == null) {
+        if (!dryRun && x[key] == null) {
           throw new Error(`Bad query: ${key} '${query}' does not exist`)
         } else {
           return x
@@ -89,7 +89,7 @@ const repoContributors =
         verbose,
         name: `repoContributors: ${user}/${repo}`,
         query: queries.repository(repo, user, before, after)
-      }).then(verifyResultHasKey('repository', user + '/' + repo))
+      }).then(verifyResultHasKey('repository', user + '/' + repo, dryRun))
       .then(json => {
         if (dryRun) {
           return json
@@ -112,7 +112,7 @@ const orgContributors = ({token, orgName, before, after, debug, dryRun, verbose}
         verbose,
         name: `orgContributors: ${orgName}`,
         query: queries.orgRepos(orgName, before, after)
-      }).then(verifyResultHasKey('organization', orgName))
+      }).then(verifyResultHasKey('organization', orgName, dryRun))
       .then(data => {
         if (dryRun) {
           return data

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ const repoContributors = ({
   dryRun,
   verbose,
   name: `repoContributors: ${user}/${repo}`,
-  query: queries.repository(repo, user, before, after)
+  query: queries.repository(repo, user, before, after, commits)
 }).then(verifyResultHasKey('repository', user + '/' + repo, dryRun))
       .then(json => {
         if (dryRun) {
@@ -119,16 +119,16 @@ const orgContributors = ({
   debug,
   dryRun,
   verbose,
-  commits,
-  reactions,
   name: `orgContributors: ${orgName}`,
-  query: queries.orgRepos(orgName, before, after)
+  query: queries.orgRepos(orgName, before, after, commits)
 }).then(verifyResultHasKey('organization', orgName, dryRun))
       .then(data => {
         if (dryRun) {
           return data
         } else {
-          return queries.cleanOrgRepos(token, data, before, after, verbose)
+          return queries.cleanOrgRepos({
+            token, result: data, before, after, verbose, commits, reactions
+          })
         }
       })
 

--- a/src/index.js
+++ b/src/index.js
@@ -103,6 +103,8 @@ const repoContributors = ({
     token,
     debug,
     dryRun,
+    before,
+    after,
     verbose,
     name: `${user}/${repo}`,
     query: queries.repository(repo, user, before, after, commits, reactions)
@@ -136,6 +138,8 @@ const orgContributors = ({
   return qfn({
     token,
     debug,
+    before,
+    after,
     dryRun,
     verbose,
     name: orgName,

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ const repoContributors = ({
   debug,
   dryRun,
   verbose,
-  name: `repoContributors: ${user}/${repo}`,
+  name: `${user}/${repo}`,
   query: queries.repository(repo, user, before, after, commits)
 }).then(verifyResultHasKey('repository', user + '/' + repo, dryRun))
       .then(json => {
@@ -119,7 +119,7 @@ const orgContributors = ({
   debug,
   dryRun,
   verbose,
-  name: `orgContributors: ${orgName}`,
+  name: orgName,
   query: queries.orgRepos(orgName, before, after, commits)
 }).then(verifyResultHasKey('organization', orgName, dryRun))
       .then(data => {

--- a/src/queries.js
+++ b/src/queries.js
@@ -115,7 +115,7 @@ const fetchAll = async ({
   token, acc, data, type, key, query, name, before, after
 }) => {
   if (data[key].pageInfo.hasNextPage) {
-    const next = await graphql.executequery({
+    const next = await graphql.execute({
       token,
       name,
       verbose: verboseCont,

--- a/src/queries.js
+++ b/src/queries.js
@@ -229,11 +229,25 @@ const orgSynopsis = ({
     }))
 }
 
+const filterOrg = (json, tf) => json
+const filterRepo = (json, tf) => json
+
+const timeFilterFullTree = (before, after, json) => {
+  const tf = timeFilter(before, after)
+
+  if (json.organisation) {
+    return filterOrg(json, tf)
+  } else {
+    return filterRepo(json, tf)
+  }
+}
+
 const cleanWhoAmI = x => x.viewer.login
 
 module.exports = {
   whoAmI,
   cleanWhoAmI,
+  timeFilterFullTree,
   repository,
   orgRepos,
   orgSynopsis,

--- a/src/queries.js
+++ b/src/queries.js
@@ -189,7 +189,9 @@ const repoSynopsis = ({json, before, after, commits, reactions}) => {
   }
 
   if (commits) {
-    const commitAuthors = repo.ref.target.history.nodes.map(x => x.author)
+    const commitAuthors = repo.ref
+          ? repo.ref.target.history.nodes.map(x => x.author)
+          : []
     const commitComments = repo.commitComments.nodes
     processed.commitAuthors = mergeContributions(users(commitAuthors))
       .sort(byCount)

--- a/src/queries.js
+++ b/src/queries.js
@@ -101,6 +101,7 @@ const repository = (repoName, ownerName, before, after, commits, reactions) =>
 const repositories = (before, after, commits, reactions) =>
       edge('repositories', {}, repoSubQuery(before, after, commits, reactions))
 
+/** Returns a query to retrieve all contributors to an org. */
 const orgRepos = (name, before, after, commits, reactions) =>
       node('organization', {login: name}, [
         repositories(before, after, commits, reactions),
@@ -113,6 +114,7 @@ const orgRepos = (name, before, after, commits, reactions) =>
 // Data Filtering (co-queries if you will)
 /// //
 
+/** Returns true iff obj.createdAt is between before and after. */
 const within = (obj, before, after) => {
   const date = new Date(obj.createdAt)
   return after <= date && date <= before
@@ -164,6 +166,9 @@ const mergeContributions = xs => {
 
 const byCount = (a, b) => b.count - a.count
 
+/** Produces a synopsis (the canonical output of name-your-contributors) of
+  * contributions to the given repo between before and after.
+  */
 const repoSynopsis = ({json, before, after, commits, reactions}) => {
   const tf = timeFilter(before, after)
   const process = x => mergeContributions(users(tf(x)))
@@ -237,6 +242,8 @@ const orgSynopsis = ({
     }))
 }
 
+/** Walks repo query result and strips out entries not between before and after.
+  */
 const filterRepo = (json, before, after) => {
   const tf = timeFilter(before, after)
   const repo = json.repository
@@ -303,6 +310,8 @@ const filterRepo = (json, before, after) => {
   return json
 }
 
+/** Walks org return JSON and strips out entries not between before and after.
+  */
 const filterOrg = (json, before, after) => {
   const org = json.organization
   const repos = org.repositories.map(repo => {
@@ -313,6 +322,7 @@ const filterOrg = (json, before, after) => {
   return json
 }
 
+/** Returns json with entires in in [before, after] stripped out. */
 const timeFilterFullTree = (json, before, after) => {
   if (json.organization) {
     return filterOrg(json, before, after)

--- a/src/queries.js
+++ b/src/queries.js
@@ -67,7 +67,8 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
   const participantsQ = authoredWithReactionsQ
         .concat(edge('comments', {}, authoredWithReactionsQ))
 
-  const reviewQ = edge('reviews', {}, authoredQ)
+  const reviewQ = edge('reviews', {}, authoredQ
+        .concat(edge('comments', {}, authoredWithReactionsQ)))
 
   const prsQ = edge('pullRequests', {},
     issueBits.concat(participantsQ.concat(reviewQ))

--- a/src/queries.js
+++ b/src/queries.js
@@ -32,6 +32,12 @@ const reactorQ = edge('reactions', {}, [userInfo, val('createdAt')])
 
 const commitAuthorQ = noid('author', {}, [userInfo])
 
+const issueBits = [
+  val('title'),
+  val('number'),
+  val('state')
+]
+
 const repoSubQuery = (before, after, commits, reactionsInQuery) => {
   const b = before.toISOString()
   const a = after.toISOString()
@@ -47,15 +53,15 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
         : authoredQ
 
   const participantsQ = authoredWithReactionsQ
-        .concat(edge('comments', {}, [authoredWithReactionsQ]))
+        .concat(edge('comments', {}, authoredWithReactionsQ))
 
-  const reviewQ = edge('reviews', {}, [authoredQ])
+  const reviewQ = edge('reviews', {}, authoredQ)
 
-  const prsQ = edge('pullRequests', {}, [
-    participantsQ.concat(reviewQ)
-  ])
+  const prsQ = edge('pullRequests', {},
+    issueBits.concat(participantsQ.concat(reviewQ))
+  )
 
-  const issuesQ = edge('issues', {}, participantsQ)
+  const issuesQ = edge('issues', {}, issueBits.concat(participantsQ))
 
   const commitCommentQ = edge('commitComments', {}, [
     authoredWithReactionsQ
@@ -71,80 +77,20 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
 }
 
 /** Returns a query to retrieve all contributors to a repo */
-const repository = (repoName, ownerName, before, after, commits) => {
-  return node('repository', {name: repoName, owner: ownerName},
-              repoSubQuery(before, after, commits))
-}
+const repository = (repoName, ownerName, before, after, commits, reactions) =>
+      node('repository', {name: repoName, owner: ownerName},
+           repoSubQuery(before, after, commits, reactions))
 
-const repositories = (before, after, commits) =>
-      edge('repositories', {}, repoSubQuery(before, after, commits))
+const repositories = (before, after, commits, reactions) =>
+      edge('repositories', {}, repoSubQuery(before, after, commits, reactions))
 
-const orgRepos = (name, before, after, commits) =>
+const orgRepos = (name, before, after, commits, reactions) =>
       node('organization', {login: name},
-           [repositories(before, after, true, commits)])
-
-const continuationQuery = ({
-  id, parentType, childType, cursor, query, before, after
-}) => {
-  const a = after && after.toISOString()
-  const b = before && before.toISOString()
-  const args = {after: cursor, first: 100}
-  if (childType === 'history') {
-    args.since = a
-    args.until = b
-  }
-  return node('node', {id})
-    .addChild(node('id'))
-    .addChild(node(`... on ${parentType}`)
-              .addChild(node(childType, args)
-                        .addChild(query)))
-}
+           [repositories(before, after, commits, reactions)])
 
 /// //
 // Data Filtering (co-queries if you will)
 /// //
-
-// Yay globals. For one off script purposes this is fine, but if we're
-// interleaving async calls to the main functions this will go awry.
-let verboseCont = false
-
-/** Recursive fetcher keeps grabbing the next page from the API until there are
-  * none left. Returns the aggregate result of all fetches.
-  */
-const fetchAll = async ({
-  token, acc, data, type, key, query, name, before, after
-}) => {
-  if (data[key].pageInfo.hasNextPage) {
-    const next = await graphql.execute({
-      token,
-      name,
-      verbose: verboseCont,
-      query: continuationQuery({
-        id: data.id,
-        parentType: type,
-        childType: key,
-        cursor: data[key].pageInfo.endCursor,
-        query,
-        before,
-        after
-      })
-    })
-
-    return fetchAll({
-      token,
-      name,
-      acc: acc.concat(next.node[key].nodes),
-      data: next.node,
-      type,
-      key,
-      query,
-      before,
-      after
-    })
-  } else {
-    return acc
-  }
-}
 
 /** Returns a function that when given an array of objects with createAt keys,
   * returns an array containing only those objects created between before and
@@ -193,173 +139,21 @@ const mergeContributions = xs => {
   return Array.from(m.values())
 }
 
-const depaginateAll = async (parent, {
-  token, acc, type, key, query, name, before, after
-}) =>
-      flatten(await Promise.all(parent.map(x => fetchAll({
-        name,
-        token,
-        type,
-        key,
-        query,
-        acc: acc(x),
-        data: x,
-        before,
-        after
-      }))))
-
 const byCount = (a, b) => b.count - a.count
 
-/** Parse repository query result and filter for date range. */
-const depaginateResponse = async ({
-  token, result, before, after, verbose, commits, reactions
-}) => {
-  verboseCont = verboseCont || verbose
-
-  let commitsCont = []
-  if (commits) {
-    commitsCont = await fetchAll({
-      token,
-      name: 'commits cont',
-      data: result.ref.target,
-      acc: result.ref.target.history.nodes,
-      type: 'Commit',
-      key: 'history',
-      query: commitHistoryQ,
-      before,
-      after
-    })
-  }
-
-  const commitAuthors = Array.from(commitsCont).map(x => x.author)
-
-  const prs = await fetchAll({
-    token,
-    name: 'prs cont',
-    acc: result.pullRequests.nodes,
-    data: result,
-    type: 'Repository',
-    key: 'pullRequests',
-    query: prsContQ
-  })
-
-  const issues = await fetchAll({
-    token,
-    name: 'issues cont',
-    acc: result.issues.nodes,
-    data: result,
-    type: 'Repository',
-    key: 'issues',
-    query: participantsQ
-  })
-
-  let commitComments = []
-  if (commits) {
-    commitComments = await fetchAll({
-      token,
-      name: 'commit comments cont',
-      acc: result.commitComments.nodes,
-      data: result,
-      type: 'Repository',
-      key: 'commitComments',
-      query: authoredWithReactionsQ
-    })
-  }
-
-  const reviews = await depaginateAll(prs, {
-    token,
-    name: 'reviews cont',
-    acc: pr => pr.reviews.nodes,
-    type: 'PullRequest',
-    key: 'reviews',
-    query: authoredQ
-  })
-
-  const prComments = await depaginateAll(prs, {
-    token,
-    name: 'pr comments cont',
-    acc: pr => pr.comments.nodes,
-    type: 'PullRequest',
-    key: 'comments',
-    query: authoredQ.addChild(reactorQ)
-  })
-
-  const issueComments = await depaginateAll(issues, {
-    token,
-    name: 'issue comments cont',
-    acc: issue => issue.comments.nodes,
-    type: 'Issue',
-    key: 'comments',
-    query: authoredQ.addChild(reactorQ)
-  })
-
-  let reactionsCont = []
-  if (reactions) {
-    reactionsCont = Array.from(await depaginateAll(commitComments, {
-      token,
-      name: 'reactions cont',
-      acc: cc => cc.reactions.nodes,
-      type: 'CommitComment',
-      key: 'reactions',
-      query: reactorSubQ
-    })).concat(await depaginateAll(issueComments, {
-      token,
-      name: 'issue comment reactions cont',
-      acc: ic => ic.reactions.nodes,
-      type: 'IssueComment',
-      key: 'reactions',
-      query: reactorSubQ
-    })).concat(await depaginateAll(prComments, {
-      token,
-      name: 'pr comment reactions cont',
-      acc: prc => prc.reactions.nodes,
-      type: 'IssueComment',
-      key: 'reactions',
-      query: reactorSubQ
-    })).concat(await depaginateAll(issues, {
-      token,
-      name: 'issue reactions cont',
-      acc: is => is.reactions.nodes,
-      type: 'Issue',
-      key: 'reactions',
-      query: reactorSubQ
-    })).concat(await depaginateAll(prs, {
-      token,
-      name: 'pullrequest reactions cont',
-      acc: pr => pr.reactions.nodes,
-      type: 'PullRequest',
-      key: 'reactions',
-      query: reactorSubQ
-    }))
-  }
-
-  const response = {
-    prs,
-    prComments,
-    issues,
-    issueComments,
-    reviews
-  }
-
-  if (commits) {
-    response.commitAuthors = commitAuthors
-    response.commitComments = commitComments
-  }
-
-  if (reactions) {
-    response.reactions = reactionsCont
-  }
-
-  return response
-}
-
-const repoSynopsis =  ({
-  prs, prComments, issues, issueComments, reviews, reactions, commitAuthors,
-  commitComments, before, after
-}) => {
+const repoSynopsis = ({json, before, after, commits, reactions}) => {
   const tf = timeFilter(before, after)
   const process = x => mergeContributions(users(tf(x)))
         .sort(byCount)
+
+  const repo = json.repository
+
+  const prs = json.repository.pullRequests.nodes
+  const prComments = flatten(prs.map(p => p.comments.nodes))
+  const reviews = flatten(prs.map(p => p.reviews))
+
+  const issues = repo.issues.nodes
+  const issueComments = flatten(issues.map(i => i.comments.nodes))
 
   const processed = {
     prCreators: process(prs),
@@ -370,32 +164,21 @@ const repoSynopsis =  ({
   }
 
   if (reactions) {
-    processed.reactors = process(reactions)
+    const reactors = issueComments.map(c => c.reactions.nodes).concat(
+      prComments.map(c => c.reactions.nodes))
+
+    processed.reactors = process(reactors)
   }
 
-  if (commitAuthors) {
+  if (commits) {
+    const commitAuthors = repo.ref.target.history.nodes.map(x => x.author)
+    const commitComments = repo.commitComments.nodes
     processed.commitAuthors = mergeContributions(users(commitAuthors))
       .sort(byCount)
-  }
-
-  if (commitComments) {
     processed.commitCommentators = process(commitComments)
   }
 
   return processed
-}
-
-const cleanRepo = async ({
-  token, result, before, after, verbose, commits, reactions
-}) => {
-  const res = await depaginateResponse({
-    token, result, before, after, verbose, commits, reactions
-  })
-
-  res.before = before
-  res.after = after
-
-  return repoSynopsis(res)
 }
 
 const mergeArrays = (a, b) =>
@@ -411,34 +194,21 @@ const mergeRepoResults = repos =>
         return ret
       })
 
-const cleanOrgRepos = async ({
-  token, result, before, after, verbose, commits, reactions
+const cleanOrgRepos = ({
+  json, before, after, commits, reactions
 }) => {
-  verboseCont = verboseCont || verbose
-
-  const repos = await fetchAll({
-    token,
-    name: 'org repos cont',
-    acc: result.organization.repositories.nodes,
-    data: result.organization,
-    type: 'Organization',
-    key: 'repositories',
-    query: repositoryCont(before, after, commits)
-  })
+  const repos = json.organization.repositories.nodes
 
   return mergeRepoResults(
-    await Promise.all(repos.map(repo => {
-      return cleanRepo({
-        token,
-        result: repo,
+    repos.map(repo => {
+      return repoSynopsis({
+        json: {repository: repo},
         commits,
         reactions,
         before,
-        after,
-        verbose
+        after
       })
     }))
-  )
 }
 
 const cleanWhoAmI = x => x.viewer.login
@@ -452,7 +222,7 @@ module.exports = {
   timeFilter,
   flatten,
   users,
-  cleanRepo,
+  repoSynopsis,
   mergeContributions,
   mergeArrays,
   mergeRepoResults,

--- a/src/queries.js
+++ b/src/queries.js
@@ -150,7 +150,7 @@ const repoSynopsis = ({json, before, after, commits, reactions}) => {
 
   const prs = json.repository.pullRequests.nodes
   const prComments = flatten(prs.map(p => p.comments.nodes))
-  const reviews = flatten(prs.map(p => p.reviews))
+  const reviews = flatten(prs.map(p => p.reviews.nodes))
 
   const issues = repo.issues.nodes
   const issueComments = flatten(issues.map(i => i.comments.nodes))
@@ -164,8 +164,9 @@ const repoSynopsis = ({json, before, after, commits, reactions}) => {
   }
 
   if (reactions) {
-    const reactors = issueComments.map(c => c.reactions.nodes).concat(
-      prComments.map(c => c.reactions.nodes))
+    const reactors = flatten(issueComments.map(c => c.reactions.nodes).concat(
+      prComments.map(c => c.reactions.nodes)
+    ))
 
     processed.reactors = process(reactors)
   }

--- a/src/queries.js
+++ b/src/queries.js
@@ -194,7 +194,7 @@ const mergeRepoResults = repos =>
         return ret
       })
 
-const cleanOrgRepos = ({
+const orgSynopsis = ({
   json, before, after, commits, reactions
 }) => {
   const repos = json.organization.repositories.nodes
@@ -218,7 +218,7 @@ module.exports = {
   cleanWhoAmI,
   repository,
   orgRepos,
-  cleanOrgRepos,
+  orgSynopsis,
   timeFilter,
   flatten,
   users,

--- a/src/queries.js
+++ b/src/queries.js
@@ -20,10 +20,15 @@ const userInfo = node('user', {}, [
 ])
 
 const authoredQ = [
-  typedNode('author', 'User', {}, [
-    val('login'),
-    val('name'),
-    val('url')
+  typedNode('author', {}, [
+    ['User', [
+      val('login'),
+      val('name'),
+      val('url')
+    ]],
+    ['Bot', [
+      val('login')
+    ]]
   ]),
   val('createdAt')
 ]
@@ -43,8 +48,10 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
   const a = after.toISOString()
 
   const masterCommits = node('ref', {qualifiedName: 'refs/heads/master'}, [
-    typedNode('target', 'Commit', {}, [
-      edge('history', {since: a, until: b}, [commitAuthorQ], true)
+    typedNode('target', {}, [
+      ['Commit', [
+        edge('history', {since: a, until: b}, [commitAuthorQ], true)
+      ]]
     ])
   ])
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -74,7 +74,13 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
     authoredWithReactionsQ
   ])
 
-  const children = [prsQ, issuesQ, val('nameWithOwner')]
+  const children = [
+    prsQ,
+    issuesQ,
+    val('homepageUrl'),
+    val('name'),
+    node('owner', {}, [val('login')])
+  ]
 
   if (commits) {
     children.push(commitCommentQ)
@@ -92,8 +98,12 @@ const repositories = (before, after, commits, reactions) =>
       edge('repositories', {}, repoSubQuery(before, after, commits, reactions))
 
 const orgRepos = (name, before, after, commits, reactions) =>
-      node('organization', {login: name},
-           [repositories(before, after, commits, reactions)])
+      node('organization', {login: name}, [
+        repositories(before, after, commits, reactions),
+        val('name'),
+        val('login'),
+        val('email')
+      ])
 
 /// //
 // Data Filtering (co-queries if you will)

--- a/src/queries.js
+++ b/src/queries.js
@@ -67,7 +67,7 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
     authoredWithReactionsQ
   ])
 
-  const children = [prsQ, issuesQ]
+  const children = [prsQ, issuesQ, val('nameWithOwner')]
 
   if (commits) {
     children.push(commitCommentQ)

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -75,15 +75,6 @@ test('Contributors before a fixed date remain static', t => {
   })
 })
 
-test('Queries without tokens get rejected', t => {
-  return main.repoContributors({
-    user: 'mntnr',
-    repo: 'name-your-contributors',
-    before: new Date(),
-    after: new Date(0)
-  }).catch(error => t.is(error.message, 'Unauthorized'))
-})
-
 test('All sorts of valid GitHub URLS', async t => {
   /* eslint-disable */
   // Need to test tabs...

--- a/test/queries-test.js
+++ b/test/queries-test.js
@@ -60,3 +60,98 @@ test('null users get filtered', t => {
   const ulist = [{author: {login: 'me', name: 'just me'}}, {author: null}]
   t.deepEqual(q.users(ulist), [{login: 'me', name: 'just me', count: 1}])
 })
+
+const tree = {
+  'repository': {
+    'homepageUrl': '',
+    'name': 'name-your-contributors',
+    'owner': {
+      'login': 'mntnr'
+    },
+    'pullRequests': [
+      {
+        'title': 'Cli updates',
+        'number': 43,
+        'state': 'MERGED',
+        'author': {
+          'login': 'tgetgood',
+          'name': 'Thomas Getgood',
+          'url': 'https://github.com/tgetgood'
+        },
+        'createdAt': '2017-10-26T19:48:39Z',
+        'comments': [
+          {
+            'author': {
+              'login': 'RichardLitt',
+              'name': 'Richard Littauer',
+              'url': 'https://github.com/RichardLitt'
+            },
+            'createdAt': '2017-11-20T16:35:31Z'
+          },
+          {
+            'author': {
+              'login': 'tgetgood',
+              'name': 'Thomas Getgood',
+              'url': 'https://github.com/tgetgood'
+            },
+            'createdAt': '2017-11-21T21:05:15Z'
+          },
+          {
+            'author': {
+              'login': 'RichardLitt',
+              'name': 'Richard Littauer',
+              'url': 'https://github.com/RichardLitt'
+            },
+            'createdAt': '2017-11-22T10:50:51Z'
+          },
+          {
+            'author': {
+              'login': 'tgetgood',
+              'name': 'Thomas Getgood',
+              'url': 'https://github.com/tgetgood'
+            },
+            'createdAt': '2017-11-22T15:47:46Z'
+          },
+          {
+            'author': {
+              'login': 'RichardLitt',
+              'name': 'Richard Littauer',
+              'url': 'https://github.com/RichardLitt'
+            },
+            'createdAt': '2017-11-22T15:58:52Z'
+          },
+          {
+            'author': {
+              'login': 'tgetgood',
+              'name': 'Thomas Getgood',
+              'url': 'https://github.com/tgetgood'
+            },
+            'createdAt': '2017-11-24T01:53:14Z'
+          },
+          {
+            'author': {
+              'login': 'RichardLitt',
+              'name': 'Richard Littauer',
+              'url': 'https://github.com/RichardLitt'
+            },
+            'createdAt': '2017-11-27T17:52:07Z'
+          }
+        ],
+        'reviews': []
+      }
+    ],
+    'issues': []
+  }
+}
+
+test('time filtering in full mode', t => {
+  const before = new Date('2017-11-23')
+  const after = new Date('2017-11-21')
+  const out = q.timeFilterFullTree(tree, before, after)
+  t.is(out.repository.pullRequests[0].comments.length, 4)
+})
+
+test('Recursive filtering in full mode', t => {
+  const date = new Date('2017-11-10')
+  t.is(q.timeFilterFullTree(tree, date, date), null)
+})


### PR DESCRIPTION
Adds a `--full` option to the CLI which returns the full tree of interactions. This allows us to see not only who commented, but when and where they did so. 

As part of this I refactored the query construction so that retrieving all of the paginated results is now automatic. We can also walk the query and use it to do some automatic transformations of the result. 

This removes a ton of boilerplate and makes everything more robust since we're not doing 85% the same thing in a dozen places. 

Addresses #51 