### PR TITLE
Grabbing user emails

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,9 @@ $ npm install --save name-your-contributors
 
 You also need to get a GitHub application token to access the API. Go here:
 https://github.com/settings/tokens. Click on "Generate New Token". It needs to
-have the `read:org` scope in order to search by organization. Name the token
-something informative: `name-your-contributors` is a good name.
+have the `read:org` and the `user:email` scopes in order to function
+properly. Name the token something informative: `name-your-contributors` is a
+good name.
 
 Set the token with the variable name `$GITHUB_TOKEN` before running the script:
 

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -123,13 +123,8 @@ const queryEdge = (name, args, children) => {
   }).addChild(queryNode('nodes', {}, children))
 }
 
-const queryOn = (type, children) => queryRoot({
-  name: `... on ${type}`,
-  args: {},
-  children,
-  type: 'on',
-  nodeType: type
-})
+const queryOn = (type, children) =>
+      queryNode(`... on ${type}`, {}, children)
 
 /** Returns a branching typecasting query node. Necessary for any node in an API
   * that returns an interface.

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -123,8 +123,13 @@ const queryEdge = (name, args, children) => {
   }).addChild(queryNode('nodes', {}, children))
 }
 
-const queryOn = (type, children) =>
-      queryNode(`... on ${type}`, {}, children)
+const queryOn = (type, children) => queryRoot({
+  name: `... on ${type}`,
+  args: {},
+  children,
+  type: 'on',
+  nodeType: type
+})
 
 /** Returns a branching typecasting query node. Necessary for any node in an API
   * that returns an interface.

--- a/src/queries.js
+++ b/src/queries.js
@@ -13,19 +13,19 @@ const typeSwitch = graphql.queryType
 
 const whoAmI = node('viewer', {}, ['login'])
 
-const userInfo = node('user', {}, [
+const userFields = [
   val('login'),
   val('name'),
+  val('email'),
+  val('avatarUrl'),
   val('url')
-])
+]
+
+const userInfo = node('user', {}, userFields)
 
 const authoredQ = [
   typeSwitch('author', {}, [
-    ['User', [
-      val('login'),
-      val('name'),
-      val('url')
-    ]],
+    ['User', userFields],
     ['Bot', [
       val('login')
     ]]


### PR DESCRIPTION
Adds user emails to queries.

Note: the GitHub token used with the app now needs the `user:email` permission. This has been added to the readme.

I also added the user's `avatarUrl` to the query since we're going to need that later. 

This PR is based off the `trace` branch since the queries were refactored. Will need to be rebased after #61 gets merged in.

Addresses #53 