### PR TITLE
Daemonised

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -120,7 +120,7 @@ const handleOut = res => {
 }
 
 const handleError = e => {
-  console.error(e.stack)
+  console.error(e)
   cleanup(1)
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,6 +4,7 @@
 const meow = require('meow')
 const main = require('./index')
 const done = require('./graphql').done
+const cache = require('./graphql').cache
 
 const cli = meow([`
   Usage
@@ -28,6 +29,8 @@ const cli = meow([`
     --local-dir   - If specified, this script will look for repos being queried in
                     the provided dir and read the commit log from them directly.
     --reactions   - Query reactions of comments as well.
+
+    --wipe-cache  - Wipe local cache before starting query.
 
     -v, --verbose - Enable verbose logging
     --debug       - Enable extremely verbose logging
@@ -60,6 +63,15 @@ const token = cli.flags.t || process.env.GITHUB_TOKEN
 
 const after = cli.flags.a ? new Date(cli.flags.a) : new Date(0)
 const before = cli.flags.b ? new Date(cli.flags.b) : new Date()
+
+if (cli.flags.wipeCache) {
+  if (cli.flags.v) {
+    console.log('Wiping cache')
+  }
+  for (const key of cache.keysSync()) {
+    cache.deleteSync(key)
+  }
+}
 
 const defaultOpts = opts => {
   opts.before = before

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -130,8 +130,13 @@ const queryEdge = (name, args, children) => {
   }).addChild(queryNode('nodes', {}, children))
 }
 
-const queryOn = (type, children) =>
-      queryNode(`... on ${type}`, {}, children)
+const queryOn = (type, children) => queryRoot({
+  name: `... on ${type}`,
+  args: {},
+  children,
+  type: 'on',
+  nodeType: type
+})
 
 /** Returns a branching typecasting query node. Necessary for any node in an API
   * that returns an interface.

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -506,19 +506,6 @@ const runQueue = () => {
       lastMinute++
       setTimeout(() => lastMinute--, 60000)
 
-      const {args, resolve, reject} = queue.shift()
-      const req = queryRequest(args)
-
-      req.then(x => {
-        process.nextTick(runQueue)
-        running = false
-      })
-
-      req.catch(e => {
-        running = false
-        reject(e)
-      })
-
       tryRun(queue)
     }
   }

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -130,13 +130,8 @@ const queryEdge = (name, args, children) => {
   }).addChild(queryNode('nodes', {}, children))
 }
 
-const queryOn = (type, children) => queryRoot({
-  name: `... on ${type}`,
-  args: {},
-  children,
-  type: 'on',
-  nodeType: type
-})
+const queryOn = (type, children) =>
+      queryNode(`... on ${type}`, {}, children)
 
 /** Returns a branching typecasting query node. Necessary for any node in an API
   * that returns an interface.

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -433,7 +433,7 @@ const untilReset = e => {
 }
 
 let running = 0
-const maxConcurrent = 10
+const maxConcurrent = 1
 
 let locked = false
 
@@ -496,7 +496,7 @@ const tryRun = queue => {
 
 /** Request pool executor. Sends the next network request if resources permit. */
 const runQueue = () => {
-  if (running > maxConcurrent) {
+  if (running >= maxConcurrent) {
     // noop
   } else if (lastMinute >= maxPerMinute) {
     setTimeout(runQueue, 1000)

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -355,13 +355,14 @@ const queryRequest = ({token, query, debug, dryRun, verbose, name}) => {
               headers: res.headers
             })
           } else {
-            console.error({
+            /*eslint-disable*/
+            reject({
               statusCode: res.statusCode,
               statusMessage: res.statusMessage,
               headers: res.headers,
               responseBody: queryResponse
             })
-            reject(new Error(res.statusMessage))
+            /*eslint-enable*/
           }
         })
       })

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -481,12 +481,16 @@ const rawResponse = args => {
     const key = sha1sum(queryWithCost(args.query, args.dryRun))
     cache.get(key, async (err, response) => {
       if (err || !response) {
-        const res = await executeOnQueue(args)
-        resolve(res)
-        caching++
-        cache.put(key, res, x => {
-          caching--
-        })
+        try {
+          const res = await executeOnQueue(args)
+          resolve(res)
+          caching++
+          cache.put(key, res, x => {
+            caching--
+          })
+        } catch (e) {
+          reject(e)
+        }
       } else {
         response.cacheHit = true
         resolve(response)

--- a/src/graphql.js
+++ b/src/graphql.js
@@ -612,6 +612,7 @@ module.exports = {
   execute,
   prune,
   done,
+  cache,
   queryNode,
   queryNoid,
   queryLeaf,

--- a/src/queries.js
+++ b/src/queries.js
@@ -81,13 +81,13 @@ const repoSubQuery = (before, after, commits, reactionsInQuery) => {
   const children = [
     prsQ,
     issuesQ,
+    commitCommentQ,
     val('homepageUrl'),
     val('name'),
     node('owner', {}, [val('login')])
   ]
 
   if (commits) {
-    children.push(commitCommentQ)
     children.push(masterCommits)
   }
   return children


### PR DESCRIPTION
This builds on #61, #62, and #63.

First step towards daemonisation. With this PR, name-your-contributors will run indefinitely, sleeping when it runs out of quota until the quota resets. Any other error response that contains a `retry-after` header will also cause the client to sleep that long and then try to continue.

This theoretically allows name-your-contributors to grab arbitrarily large sets of data politely over time. I've tested it but almost exhausting my quota and then grabbing something large. I'm still running larger tests, looking for something that takes more than 10k quota to see that it sleeps multiple times. With the recent query optimisations I'm actually having trouble finding a simple query that expensive. 

At this point I'm as confident that I reasonably can be that it works. Give it a shot.
  
One caveat: GitHub does not like you making more than one request in parallel with the same API token. That means that if you run nyc in multiple terminals at once, they will, in concert set off the abuse alarm. They won't fail, they'll simply go to sleep every time the alarm goes off and try again later. This can lead to reduced performance. This isn't a new problem; it's just more obvious now that the script can run longterm.