### PR TITLE
build(travis): added build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
 before_script:
   - npm prune
   - greenkeeper-lockfile-update
-after_success:
-  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
@@ -19,3 +17,15 @@ before_install:
 - npm install -g npm@5
 - npm install -g greenkeeper-lockfile@1
 after_script: greenkeeper-lockfile-upload
+jobs:
+  include:
+    - stage: release
+      script: skip
+      deploy:
+        provider: script
+        skip_cleanup: true,
+        script: npm run semantic-release
+stages:
+  - test
+  - name: release
+    if: branch = master

--- a/package-lock.json
+++ b/package-lock.json
@@ -2915,7 +2915,6 @@
 			"requires": {
 				"anymatch": "^1.3.0",
 				"async-each": "^1.0.0",
-				"fsevents": "^1.0.0",
 				"glob-parent": "^2.0.0",
 				"inherits": "^2.0.1",
 				"is-binary-path": "^1.0.0",
@@ -3612,7 +3611,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -4724,910 +4722,6 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true
 		},
-		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"nan": "^2.3.0",
-				"node-pre-gyp": "^0.6.39"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "^4.6.0",
-						"json-stable-stringify": "^1.0.1"
-					}
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true,
-					"dev": true
-				},
-				"aproba": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true,
-					"dev": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "^0.14.3"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "~2.0.0"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.x.x"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "^0.4.1",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"caseless": {
-					"version": "0.12.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"co": {
-					"version": "4.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.x.x"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"debug": {
-					"version": "2.6.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.4.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.5",
-						"mime-types": "^2.1.12"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"inherits": "~2.0.0",
-						"mkdirp": ">=0.5 0",
-						"rimraf": "2"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fstream": "^1.0.0",
-						"inherits": "2",
-						"minimatch": "^3.0.0"
-					}
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "^1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"ajv": "^4.9.1",
-						"har-schema": "^1.0.5"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.x.x",
-						"cryptiles": "2.x.x",
-						"hoek": "2.x.x",
-						"sntp": "1.x.x"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true,
-					"dev": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "^0.2.0",
-						"jsprim": "^1.2.2",
-						"sshpk": "^1.7.0"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true,
-					"dev": true
-				},
-				"ini": {
-					"version": "1.3.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "~0.1.0"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "~0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true,
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mime-db": "~1.27.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true,
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"node-pre-gyp": {
-					"version": "0.6.39",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"hawk": "3.1.3",
-						"mkdirp": "^0.5.1",
-						"nopt": "^4.0.1",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"request": "2.81.0",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^2.2.1",
-						"tar-pack": "^3.4.0"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true,
-					"dev": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "~0.4.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-shims": "~1.0.0",
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~1.0.6",
-						"string_decoder": "~1.0.0",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"aws-sign2": "~0.6.0",
-						"aws4": "^1.2.1",
-						"caseless": "~0.12.0",
-						"combined-stream": "~1.0.5",
-						"extend": "~3.0.0",
-						"forever-agent": "~0.6.1",
-						"form-data": "~2.1.1",
-						"har-validator": "~4.2.1",
-						"hawk": "~3.1.3",
-						"http-signature": "~1.1.0",
-						"is-typedarray": "~1.0.0",
-						"isstream": "~0.1.2",
-						"json-stringify-safe": "~5.0.1",
-						"mime-types": "~2.1.7",
-						"oauth-sign": "~0.8.1",
-						"performance-now": "^0.2.0",
-						"qs": "~6.4.0",
-						"safe-buffer": "^5.0.1",
-						"stringstream": "~0.0.4",
-						"tough-cookie": "~2.3.0",
-						"tunnel-agent": "^0.6.0",
-						"uuid": "^3.0.0"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"glob": "^7.0.5"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"semver": {
-					"version": "5.3.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.x.x"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asn1": "~0.2.3",
-						"assert-plus": "^1.0.0",
-						"bcrypt-pbkdf": "^1.0.0",
-						"dashdash": "^1.12.0",
-						"ecc-jsbn": "~0.1.1",
-						"getpass": "^0.1.1",
-						"jodid25519": "^1.0.0",
-						"jsbn": "~0.1.0",
-						"tweetnacl": "~0.14.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"block-stream": "*",
-						"fstream": "^1.0.2",
-						"inherits": "2"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"debug": "^2.2.0",
-						"fstream": "^1.0.10",
-						"fstream-ignore": "^1.0.5",
-						"once": "^1.3.3",
-						"readable-stream": "^2.1.4",
-						"rimraf": "^2.5.1",
-						"tar": "^2.2.1",
-						"uid-number": "^0.0.6"
-					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"punycode": "^1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "^5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"string-width": "^1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				}
-			}
-		},
 		"function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6437,8 +5531,7 @@
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-			"dev": true
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
 		},
 		"is-subset": {
 			"version": "0.1.1",
@@ -6491,8 +5584,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "2.1.0",
@@ -7114,13 +6206,6 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-			"dev": true,
-			"optional": true
-		},
 		"nanomatch": {
 			"version": "1.2.13",
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -7175,8 +6260,7 @@
 		"nice-try": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
-			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
-			"dev": true
+			"integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
 		},
 		"node-emoji": {
 			"version": "1.8.1",
@@ -7386,7 +6470,8 @@
 			"dependencies": {
 				"JSONStream": {
 					"version": "1.3.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
 					"dev": true,
 					"requires": {
 						"jsonparse": "^1.2.0",
@@ -7395,12 +6480,14 @@
 				},
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true
 				},
 				"agent-base": {
 					"version": "4.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
 					"dev": true,
 					"requires": {
 						"es6-promisify": "^5.0.0"
@@ -7408,7 +6495,8 @@
 				},
 				"agentkeepalive": {
 					"version": "3.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MPIwsZU9PP9kOrZpyu2042kYA8Fdt/AedQYkYXucHgF9QoD9dXVp0ypuGnHXSR0hTstBxdt85Xkh4JolYfK5wg==",
 					"dev": true,
 					"requires": {
 						"humanize-ms": "^1.2.1"
@@ -7416,7 +6504,8 @@
 				},
 				"ajv": {
 					"version": "5.5.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 					"dev": true,
 					"requires": {
 						"co": "^4.6.0",
@@ -7427,7 +6516,8 @@
 				},
 				"ansi-align": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0"
@@ -7435,12 +6525,14 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -7448,27 +6540,32 @@
 				},
 				"ansicolors": {
 					"version": "0.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
 					"dev": true
 				},
 				"ansistyles": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
 					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true
 				},
 				"archy": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
 					"dev": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
@@ -7477,12 +6574,14 @@
 				},
 				"asap": {
 					"version": "2.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
 					"dev": true
 				},
 				"asn1": {
 					"version": "0.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 					"dev": true,
 					"requires": {
 						"safer-buffer": "~2.1.0"
@@ -7490,32 +6589,38 @@
 				},
 				"assert-plus": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
 					"dev": true
 				},
 				"asynckit": {
 					"version": "0.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 					"dev": true
 				},
 				"aws-sign2": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
 					"dev": true
 				},
 				"aws4": {
 					"version": "1.8.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
 					"dev": true
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true
 				},
 				"bcrypt-pbkdf": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -7524,7 +6629,8 @@
 				},
 				"bin-links": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-8eEHVgYP03nILphilltWjeIjMbKyJo3wvp9K816pHbhP301ismzw15mxAAEVQ/USUwcP++1uNrbERbp8lOA6Fg==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.0",
@@ -7536,7 +6642,8 @@
 				},
 				"block-stream": {
 					"version": "0.0.9",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 					"dev": true,
 					"requires": {
 						"inherits": "~2.0.0"
@@ -7544,12 +6651,14 @@
 				},
 				"bluebird": {
 					"version": "3.5.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
 					"dev": true
 				},
 				"boxen": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
 					"dev": true,
 					"requires": {
 						"ansi-align": "^2.0.0",
@@ -7563,7 +6672,8 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -7572,32 +6682,38 @@
 				},
 				"buffer-from": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
 					"dev": true
 				},
 				"builtin-modules": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 					"dev": true
 				},
 				"builtins": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
 					"dev": true
 				},
 				"byline": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
 					"dev": true
 				},
 				"byte-size": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JGC3EV2bCzJH/ENSh3afyJrH4vwxbHTuO5ljLoI5+2iJOcEpMgP8T782jH9b5qGxf2mSUIp1lfGnfKNrRHpvVg==",
 					"dev": true
 				},
 				"cacache": {
 					"version": "11.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
@@ -7618,27 +6734,32 @@
 				},
 				"call-limit": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-b9YbA/PaQqLNDsK2DwK9DnGZH+o=",
 					"dev": true
 				},
 				"camelcase": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 					"dev": true
 				},
 				"capture-stack-trace": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
 					"dev": true
 				},
 				"caseless": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
 					"dev": true
 				},
 				"chalk": {
 					"version": "2.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
@@ -7648,17 +6769,20 @@
 				},
 				"chownr": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
 					"dev": true
 				},
 				"ci-info": {
 					"version": "1.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
 					"dev": true
 				},
 				"cidr-regex": {
 					"version": "2.0.9",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-F7/fBRUU45FnvSPjXdpIrc++WRSBdCiSTlyq4ZNhLKOlHFNWgtzZ0Fd+zrqI/J1j0wmlx/f5ZQDmD2GcbrNcmw==",
 					"dev": true,
 					"requires": {
 						"ip-regex": "^2.1.0"
@@ -7666,12 +6790,14 @@
 				},
 				"cli-boxes": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
 					"dev": true
 				},
 				"cli-columns": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.0.0",
@@ -7680,7 +6806,8 @@
 				},
 				"cli-table3": {
 					"version": "0.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-c7YHpUyO1SaKaO7kYtxd5NZ8FjAmSK3LpKkuzdwn+2CwpFxBpdoQLm+OAnnCfoEl7onKhN9PKQi1lsHuAIUqGQ==",
 					"dev": true,
 					"requires": {
 						"colors": "^1.1.2",
@@ -7690,7 +6817,8 @@
 				},
 				"cliui": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1",
@@ -7700,12 +6828,14 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -7715,12 +6845,14 @@
 				},
 				"clone": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 					"dev": true
 				},
 				"cmd-shim": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -7729,17 +6861,20 @@
 				},
 				"co": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"color-convert": {
 					"version": "1.9.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 					"dev": true,
 					"requires": {
 						"color-name": "^1.1.1"
@@ -7747,18 +6882,21 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"colors": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
 					"dev": true,
 					"optional": true
 				},
 				"columnify": {
 					"version": "1.5.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
 					"dev": true,
 					"requires": {
 						"strip-ansi": "^3.0.0",
@@ -7767,7 +6905,8 @@
 				},
 				"combined-stream": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 					"dev": true,
 					"requires": {
 						"delayed-stream": "~1.0.0"
@@ -7775,12 +6914,14 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true
 				},
 				"concat-stream": {
 					"version": "1.6.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -7791,7 +6932,8 @@
 				},
 				"config-chain": {
 					"version": "1.1.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4",
@@ -7800,7 +6942,8 @@
 				},
 				"configstore": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
 					"dev": true,
 					"requires": {
 						"dot-prop": "^4.1.0",
@@ -7813,12 +6956,14 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true
 				},
 				"copy-concurrently": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -7831,19 +6976,22 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						}
 					}
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true
 				},
 				"create-error-class": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 					"dev": true,
 					"requires": {
 						"capture-stack-trace": "^1.0.0"
@@ -7851,7 +6999,8 @@
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -7861,17 +7010,20 @@
 				},
 				"crypto-random-string": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 					"dev": true
 				},
 				"cyclist": {
 					"version": "0.2.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
 					"dev": true
 				},
 				"dashdash": {
 					"version": "1.14.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -7879,7 +7031,8 @@
 				},
 				"debug": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
 					"dev": true,
 					"requires": {
 						"ms": "2.0.0"
@@ -7887,34 +7040,40 @@
 					"dependencies": {
 						"ms": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 							"dev": true
 						}
 					}
 				},
 				"debuglog": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
 					"dev": true
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"decode-uri-component": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
 					"dev": true
 				},
 				"deep-extend": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
 					"dev": true
 				},
 				"defaults": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
 					"dev": true,
 					"requires": {
 						"clone": "^1.0.2"
@@ -7922,27 +7081,32 @@
 				},
 				"delayed-stream": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true
 				},
 				"detect-indent": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
 					"dev": true
 				},
 				"detect-newline": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
 					"dev": true
 				},
 				"dezalgo": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
 					"dev": true,
 					"requires": {
 						"asap": "^2.0.0",
@@ -7951,7 +7115,8 @@
 				},
 				"dot-prop": {
 					"version": "4.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 					"dev": true,
 					"requires": {
 						"is-obj": "^1.0.0"
@@ -7959,17 +7124,20 @@
 				},
 				"dotenv": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
 					"dev": true
 				},
 				"duplexer3": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
 					"dev": true
 				},
 				"duplexify": {
 					"version": "3.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.0.0",
@@ -7980,7 +7148,8 @@
 				},
 				"ecc-jsbn": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -7990,12 +7159,14 @@
 				},
 				"editor": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
 					"dev": true
 				},
 				"encoding": {
 					"version": "0.1.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
 					"dev": true,
 					"requires": {
 						"iconv-lite": "~0.4.13"
@@ -8003,7 +7174,8 @@
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
@@ -8011,12 +7183,14 @@
 				},
 				"err-code": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
 					"dev": true
 				},
 				"errno": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
 					"dev": true,
 					"requires": {
 						"prr": "~1.0.1"
@@ -8024,12 +7198,14 @@
 				},
 				"es6-promise": {
 					"version": "4.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
 					"dev": true
 				},
 				"es6-promisify": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
 					"dev": true,
 					"requires": {
 						"es6-promise": "^4.0.3"
@@ -8037,12 +7213,14 @@
 				},
 				"escape-string-regexp": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -8056,37 +7234,44 @@
 				},
 				"extend": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 					"dev": true
 				},
 				"extsprintf": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 					"dev": true
 				},
 				"fast-deep-equal": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
 					"dev": true
 				},
 				"fast-json-stable-stringify": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
 					"dev": true
 				},
 				"figgy-pudding": {
 					"version": "3.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
 					"dev": true
 				},
 				"find-npm-prefix": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==",
 					"dev": true
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -8094,7 +7279,8 @@
 				},
 				"flush-write-stream": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -8103,12 +7289,14 @@
 				},
 				"forever-agent": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
 					"dev": true
 				},
 				"form-data": {
 					"version": "2.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 					"dev": true,
 					"requires": {
 						"asynckit": "^0.4.0",
@@ -8118,7 +7306,8 @@
 				},
 				"from2": {
 					"version": "2.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -8127,7 +7316,8 @@
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -8135,7 +7325,8 @@
 				},
 				"fs-vacuum": {
 					"version": "1.2.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -8145,7 +7336,8 @@
 				},
 				"fs-write-stream-atomic": {
 					"version": "1.0.10",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -8156,19 +7348,22 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						}
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true
 				},
 				"fstream": {
 					"version": "1.0.11",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -8179,7 +7374,8 @@
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.0.3",
@@ -8194,7 +7390,8 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -8206,12 +7403,14 @@
 				},
 				"genfun": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-7RAEHy5KfxsKOEZtF6XD4n3x38E=",
 					"dev": true
 				},
 				"gentle-fs": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-cEng5+3fuARewXktTEGbwsktcldA+YsnUEaXZwcK/3pjSE1X9ObnTs+/8rYf8s+RnIcQm2D5x3rwpN7Zom8Bew==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2",
@@ -8226,24 +7425,28 @@
 					"dependencies": {
 						"iferr": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 							"dev": true
 						}
 					}
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"getpass": {
 					"version": "0.1.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0"
@@ -8251,7 +7454,8 @@
 				},
 				"glob": {
 					"version": "7.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
@@ -8264,7 +7468,8 @@
 				},
 				"global-dirs": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
 					"dev": true,
 					"requires": {
 						"ini": "^1.3.4"
@@ -8272,7 +7477,8 @@
 				},
 				"got": {
 					"version": "6.7.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 					"dev": true,
 					"requires": {
 						"create-error-class": "^3.0.0",
@@ -8290,17 +7496,20 @@
 				},
 				"graceful-fs": {
 					"version": "4.1.15",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
 					"dev": true
 				},
 				"har-schema": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
 					"dev": true
 				},
 				"har-validator": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 					"dev": true,
 					"requires": {
 						"ajv": "^5.3.0",
@@ -8309,27 +7518,32 @@
 				},
 				"has-flag": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "2.7.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
 					"dev": true
 				},
 				"http-cache-semantics": {
 					"version": "3.8.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
 					"dev": true
 				},
 				"http-proxy-agent": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
 					"dev": true,
 					"requires": {
 						"agent-base": "4",
@@ -8338,7 +7552,8 @@
 				},
 				"http-signature": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -8348,7 +7563,8 @@
 				},
 				"https-proxy-agent": {
 					"version": "2.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
 					"dev": true,
 					"requires": {
 						"agent-base": "^4.1.0",
@@ -8357,7 +7573,8 @@
 				},
 				"humanize-ms": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
 					"dev": true,
 					"requires": {
 						"ms": "^2.0.0"
@@ -8365,7 +7582,8 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.23",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
 					"dev": true,
 					"requires": {
 						"safer-buffer": ">= 2.1.2 < 3"
@@ -8373,12 +7591,14 @@
 				},
 				"iferr": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg==",
 					"dev": true
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"dev": true,
 					"requires": {
 						"minimatch": "^3.0.4"
@@ -8386,17 +7606,20 @@
 				},
 				"import-lazy": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
 					"dev": true
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"requires": {
 						"once": "^1.3.0",
@@ -8405,17 +7628,20 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true
 				},
 				"init-package-json": {
 					"version": "1.10.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -8430,22 +7656,26 @@
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 					"dev": true
 				},
 				"ip": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
 					"dev": true
 				},
 				"ip-regex": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
 					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 					"dev": true,
 					"requires": {
 						"builtin-modules": "^1.0.0"
@@ -8453,7 +7683,8 @@
 				},
 				"is-ci": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 					"dev": true,
 					"requires": {
 						"ci-info": "^1.0.0"
@@ -8461,7 +7692,8 @@
 				},
 				"is-cidr": {
 					"version": "2.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-A578p1dV22TgPXn6NCaDAPj6vJvYsBgAzUrAd28a4oldeXJjWqEUuSZOLIW3im51mazOKsoyVp8NU/OItlWacw==",
 					"dev": true,
 					"requires": {
 						"cidr-regex": "^2.0.8"
@@ -8469,7 +7701,8 @@
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -8477,7 +7710,8 @@
 				},
 				"is-installed-globally": {
 					"version": "0.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 					"dev": true,
 					"requires": {
 						"global-dirs": "^0.1.0",
@@ -8486,17 +7720,20 @@
 				},
 				"is-npm": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
 					"dev": true
 				},
 				"is-obj": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
 					"dev": true
 				},
 				"is-path-inside": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 					"dev": true,
 					"requires": {
 						"path-is-inside": "^1.0.1"
@@ -8504,73 +7741,87 @@
 				},
 				"is-redirect": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
 					"dev": true
 				},
 				"is-retry-allowed": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"is-typedarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 					"dev": true
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"isstream": {
 					"version": "0.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
 					"dev": true
 				},
 				"jsbn": {
 					"version": "0.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 					"dev": true,
 					"optional": true
 				},
 				"json-parse-better-errors": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
 					"dev": true
 				},
 				"json-schema": {
 					"version": "0.2.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
 					"dev": true
 				},
 				"json-schema-traverse": {
 					"version": "0.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
 					"dev": true
 				},
 				"json-stringify-safe": {
 					"version": "5.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
 					"dev": true
 				},
 				"jsonparse": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
 					"dev": true
 				},
 				"jsprim": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "1.0.0",
@@ -8581,7 +7832,8 @@
 				},
 				"latest-version": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 					"dev": true,
 					"requires": {
 						"package-json": "^4.0.0"
@@ -8589,12 +7841,14 @@
 				},
 				"lazy-property": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
 					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -8602,7 +7856,8 @@
 				},
 				"libcipm": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-9uZ6/LAflVEijksTRq/RX0e+pGA4mr8tND9Cmk2JMg7j2fFUBrs8PpFX2DOAJR/XoxPzz+5h8bkWmtIYLunKAg==",
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
@@ -8623,7 +7878,8 @@
 				},
 				"libnpmhook": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3qqpfqvBD1712WA6iGe0stkG40WwAeoWcujA6BlC0Be1JArQbqwabnEnZ0CRcD05Tf1fPYJYdCbSfcfedEJCOg==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.1.0",
@@ -8632,7 +7888,8 @@
 					"dependencies": {
 						"npm-registry-fetch": {
 							"version": "3.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-xBobENeenvjIG8PgQ1dy77AXTI25IbYhmA3DusMIfw/4EL5BaQ5e1V9trkPrqHvyjR3/T0cnH6o0Wt/IzcI5Ag==",
 							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
@@ -8646,7 +7903,8 @@
 				},
 				"libnpx": {
 					"version": "10.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-X28coei8/XRCt15cYStbLBph+KGhFra4VQhRBPuH/HHMkC5dxM8v24RVgUsvODKCrUZ0eTgiTqJp6zbl0sskQQ==",
 					"dev": true,
 					"requires": {
 						"dotenv": "^5.0.1",
@@ -8661,7 +7919,8 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -8670,7 +7929,8 @@
 				},
 				"lock-verify": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-QNVwK0EGZBS4R3YQ7F1Ox8p41Po9VGl2QG/2GsuvTbkJZYSsPeWHKMbbH6iZMCHWSMww5nrJroZYnGzI4cePuw==",
 					"dev": true,
 					"requires": {
 						"npm-package-arg": "^5.1.2 || 6",
@@ -8679,7 +7939,8 @@
 				},
 				"lockfile": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
 					"dev": true,
 					"requires": {
 						"signal-exit": "^3.0.2"
@@ -8687,12 +7948,14 @@
 				},
 				"lodash._baseindexof": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
 					"dev": true
 				},
 				"lodash._baseuniq": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
 					"dev": true,
 					"requires": {
 						"lodash._createset": "~4.0.0",
@@ -8701,17 +7964,20 @@
 				},
 				"lodash._bindcallback": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
 					"dev": true
 				},
 				"lodash._cacheindexof": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
 					"dev": true
 				},
 				"lodash._createcache": {
 					"version": "3.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
 					"dev": true,
 					"requires": {
 						"lodash._getnative": "^3.0.0"
@@ -8719,52 +7985,62 @@
 				},
 				"lodash._createset": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
 					"dev": true
 				},
 				"lodash._getnative": {
 					"version": "3.9.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
 					"dev": true
 				},
 				"lodash._root": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
 					"dev": true
 				},
 				"lodash.clonedeep": {
 					"version": "4.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 					"dev": true
 				},
 				"lodash.restparam": {
 					"version": "3.6.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
 					"dev": true
 				},
 				"lodash.union": {
 					"version": "4.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
 					"dev": true
 				},
 				"lodash.uniq": {
 					"version": "4.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 					"dev": true
 				},
 				"lodash.without": {
 					"version": "4.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
 					"dev": true
 				},
 				"lowercase-keys": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
@@ -8773,7 +8049,8 @@
 				},
 				"make-dir": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 					"dev": true,
 					"requires": {
 						"pify": "^3.0.0"
@@ -8781,7 +8058,8 @@
 				},
 				"make-fetch-happen": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
 					"dev": true,
 					"requires": {
 						"agentkeepalive": "^3.4.1",
@@ -8799,12 +8077,14 @@
 				},
 				"meant": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
 					"dev": true
 				},
 				"mem": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -8812,12 +8092,14 @@
 				},
 				"mime-db": {
 					"version": "1.35.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
 					"dev": true
 				},
 				"mime-types": {
 					"version": "2.1.19",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
 					"dev": true,
 					"requires": {
 						"mime-db": "~1.35.0"
@@ -8825,12 +8107,14 @@
 				},
 				"mimic-fn": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 					"dev": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
@@ -8838,12 +8122,14 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"minipass": {
 					"version": "2.3.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/jAn9/tEX4gnpyRATxgHEOV6xbcyxgT7iUnxo9Y3+OB0zX00TgKIv/2FZCf5brBbICcwbLqVv2ImjvWWrQMSYw==",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
@@ -8852,14 +8138,16 @@
 					"dependencies": {
 						"yallist": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
 							"dev": true
 						}
 					}
 				},
 				"minizlib": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
 					"dev": true,
 					"requires": {
 						"minipass": "^2.2.1"
@@ -8867,7 +8155,8 @@
 				},
 				"mississippi": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
 					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.0",
@@ -8884,7 +8173,8 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -8892,7 +8182,8 @@
 				},
 				"move-concurrently": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1",
@@ -8905,17 +8196,20 @@
 				},
 				"ms": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"dev": true
 				},
 				"mute-stream": {
 					"version": "0.0.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
 					"dev": true
 				},
 				"node-fetch-npm": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
 					"dev": true,
 					"requires": {
 						"encoding": "^0.1.11",
@@ -8925,7 +8219,8 @@
 				},
 				"node-gyp": {
 					"version": "3.8.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
 					"dev": true,
 					"requires": {
 						"fstream": "^1.0.0",
@@ -8944,7 +8239,8 @@
 					"dependencies": {
 						"nopt": {
 							"version": "3.0.6",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 							"dev": true,
 							"requires": {
 								"abbrev": "1"
@@ -8952,12 +8248,14 @@
 						},
 						"semver": {
 							"version": "5.3.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
 							"dev": true
 						},
 						"tar": {
 							"version": "2.2.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 							"dev": true,
 							"requires": {
 								"block-stream": "*",
@@ -8969,7 +8267,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"requires": {
 						"abbrev": "1",
@@ -8978,7 +8277,8 @@
 				},
 				"normalize-package-data": {
 					"version": "2.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
@@ -8989,7 +8289,8 @@
 				},
 				"npm-audit-report": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-SjTF8ZP4rOu3JiFrTMi4M1CmVo2tni2sP4TzhyCMHwnMGf6XkdGLZKt9cdZ12esKf0mbQqFyU9LtY0SoeahL7g==",
 					"dev": true,
 					"requires": {
 						"cli-table3": "^0.5.0",
@@ -8998,17 +8299,20 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g==",
 					"dev": true
 				},
 				"npm-cache-filename": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
 					"dev": true
 				},
 				"npm-install-checks": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
 					"dev": true,
 					"requires": {
 						"semver": "^2.3.0 || 3.x || 4 || 5"
@@ -9016,7 +8320,8 @@
 				},
 				"npm-lifecycle": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-QbBfLlGBKsktwBZLj6AviHC6Q9Y3R/AY4a2PYSIRhSKSS0/CxRyD/PfxEX6tPeOCXQgMSNdwGeECacstgptc+g==",
 					"dev": true,
 					"requires": {
 						"byline": "^5.0.0",
@@ -9031,12 +8336,14 @@
 				},
 				"npm-logical-tree": {
 					"version": "1.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg==",
 					"dev": true
 				},
 				"npm-package-arg": {
 					"version": "6.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-zYbhP2k9DbJhA0Z3HKUePUgdB1x7MfIfKssC+WLPFMKTBZKpZh5m13PgexJjCq6KW7j17r0jHWcCpxEqnnncSA==",
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.6.0",
@@ -9047,7 +8354,8 @@
 				},
 				"npm-packlist": {
 					"version": "1.1.12",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
 					"dev": true,
 					"requires": {
 						"ignore-walk": "^3.0.1",
@@ -9056,7 +8364,8 @@
 				},
 				"npm-pick-manifest": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-q9zLP8cTr8xKPmMZN3naxp1k/NxVFsjxN6uWuO1tiw9gxg7wZWQ/b5UTfzD0ANw2q1lQxdLKTeCCksq+bPSgbQ==",
 					"dev": true,
 					"requires": {
 						"npm-package-arg": "^6.0.0",
@@ -9065,7 +8374,8 @@
 				},
 				"npm-profile": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-rEJOFR6PbwOvvhGa2YTNOJQKNuc6RovJ6T50xPU7pS9h/zKPNCJ+VHZY2OFXyZvEi+UQYtHRTp8O/YM3tUD20A==",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
@@ -9074,7 +8384,8 @@
 				},
 				"npm-registry-client": {
 					"version": "8.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Qs6P6nnopig+Y8gbzpeN/dkt+n7IyVd8f45NTMotGk6Qo7GfBmzwYx6jRLoOOgKiMnaQfYxsuyQlD8Mc3guBhg==",
 					"dev": true,
 					"requires": {
 						"concat-stream": "^1.5.2",
@@ -9093,12 +8404,14 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 							"dev": true
 						},
 						"ssri": {
 							"version": "5.3.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
@@ -9108,7 +8421,8 @@
 				},
 				"npm-registry-fetch": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-XJPIBfMtgaooRtZmuA42xCeLf3tkxdIX0xqRsGWwNrcVvJ9UYFccD7Ho7QWCzvkM3i/QrkUC37Hu0a+vDBmt5g==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
@@ -9121,7 +8435,8 @@
 					"dependencies": {
 						"cacache": {
 							"version": "10.0.4",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
 							"dev": true,
 							"requires": {
 								"bluebird": "^3.5.1",
@@ -9141,7 +8456,8 @@
 							"dependencies": {
 								"mississippi": {
 									"version": "2.0.0",
-									"bundled": true,
+									"resolved": false,
+									"integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
 									"dev": true,
 									"requires": {
 										"concat-stream": "^1.5.0",
@@ -9160,12 +8476,14 @@
 						},
 						"figgy-pudding": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-yIJPhIBi/oFdU/P+GSXjmk/rmGjuZkm7A5LTXZxNrEprXJXRK012FiI1BR1Pga+0d/d6taWWD+B5d2ozqaxHig==",
 							"dev": true
 						},
 						"make-fetch-happen": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-FmWY7gC0mL6Z4N86vE14+m719JKE4H0A+pyiOH18B025gF/C113pyfb4gHDDYP5cqnRMHOz06JGdmffC/SES+w==",
 							"dev": true,
 							"requires": {
 								"agentkeepalive": "^3.4.1",
@@ -9183,7 +8501,8 @@
 						},
 						"pump": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
@@ -9192,12 +8511,14 @@
 						},
 						"smart-buffer": {
 							"version": "1.1.15",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY=",
 							"dev": true
 						},
 						"socks": {
 							"version": "1.1.10",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-W4t/x8jzQcU+0FbpKbe/Tei6e1o=",
 							"dev": true,
 							"requires": {
 								"ip": "^1.1.4",
@@ -9206,7 +8527,8 @@
 						},
 						"socks-proxy-agent": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-ZwEDymm204mTzvdqyUqOdovVr2YRd2NYskrYrF2LXyZ9qDiMAoFESGK8CRphiO7rtbo2Y757k2Nia3x2hGtalA==",
 							"dev": true,
 							"requires": {
 								"agent-base": "^4.1.0",
@@ -9215,7 +8537,8 @@
 						},
 						"ssri": {
 							"version": "5.3.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.1"
@@ -9225,7 +8548,8 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -9233,12 +8557,14 @@
 				},
 				"npm-user-validate": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jOyg9c6gTU6TUZ73LQVXp1Ei6VE=",
 					"dev": true
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"requires": {
 						"are-we-there-yet": "~1.1.2",
@@ -9249,22 +8575,26 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"oauth-sign": {
 					"version": "0.9.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -9272,17 +8602,20 @@
 				},
 				"opener": {
 					"version": "1.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
 					"dev": true
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -9292,12 +8625,14 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"requires": {
 						"os-homedir": "^1.0.0",
@@ -9306,12 +8641,14 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
 					"dev": true,
 					"requires": {
 						"p-try": "^1.0.0"
@@ -9319,7 +8656,8 @@
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -9327,12 +8665,14 @@
 				},
 				"p-try": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"package-json": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 					"dev": true,
 					"requires": {
 						"got": "^6.7.1",
@@ -9343,7 +8683,8 @@
 				},
 				"pacote": {
 					"version": "8.1.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-wTOOfpaAQNEQNtPEx92x9Y9kRWVu45v583XT8x2oEV2xRB74+xdqMZIeGW4uFvAyZdmSBtye+wKdyyLaT8pcmw==",
 					"dev": true,
 					"requires": {
 						"bluebird": "^3.5.1",
@@ -9375,7 +8716,8 @@
 				},
 				"parallel-transform": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
 					"dev": true,
 					"requires": {
 						"cyclist": "~0.2.2",
@@ -9385,52 +8727,62 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true
 				},
 				"path-is-inside": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"performance-now": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
 				},
 				"prepend-http": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 					"dev": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"dev": true
 				},
 				"promise-inflight": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
 					"dev": true
 				},
 				"promise-retry": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
 					"dev": true,
 					"requires": {
 						"err-code": "^1.0.0",
@@ -9439,14 +8791,16 @@
 					"dependencies": {
 						"retry": {
 							"version": "0.10.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
 							"dev": true
 						}
 					}
 				},
 				"promzard": {
 					"version": "0.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
 					"dev": true,
 					"requires": {
 						"read": "1"
@@ -9454,12 +8808,14 @@
 				},
 				"proto-list": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
 					"dev": true
 				},
 				"protoduck": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-agsGWD8/RZrS4ga6v82Fxb0RHIS2RZnbsSue6A9/MBRhB/jcqOANAMNrqM9900b8duj+Gx+T/JMy5IowDoO/hQ==",
 					"dev": true,
 					"requires": {
 						"genfun": "^4.0.1"
@@ -9467,22 +8823,26 @@
 				},
 				"prr": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 					"dev": true
 				},
 				"psl": {
 					"version": "1.1.29",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
 					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -9491,7 +8851,8 @@
 				},
 				"pumpify": {
 					"version": "1.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
 					"dev": true,
 					"requires": {
 						"duplexify": "^3.6.0",
@@ -9501,7 +8862,8 @@
 					"dependencies": {
 						"pump": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
 							"dev": true,
 							"requires": {
 								"end-of-stream": "^1.1.0",
@@ -9512,22 +8874,26 @@
 				},
 				"punycode": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				},
 				"qrcode-terminal": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
 					"dev": true
 				},
 				"qs": {
 					"version": "6.5.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 					"dev": true
 				},
 				"query-string": {
 					"version": "6.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-pNB/Gr8SA8ff8KpUFM36o/WFAlthgaThka5bV19AD9PNTH20Pwq5Zxodif2YyHwrctp6SkL4GqlOot0qR/wGaw==",
 					"dev": true,
 					"requires": {
 						"decode-uri-component": "^0.2.0",
@@ -9536,12 +8902,14 @@
 				},
 				"qw": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=",
 					"dev": true
 				},
 				"rc": {
 					"version": "1.2.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"dev": true,
 					"requires": {
 						"deep-extend": "^0.5.1",
@@ -9552,14 +8920,16 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true
 						}
 					}
 				},
 				"read": {
 					"version": "1.0.7",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
 					"dev": true,
 					"requires": {
 						"mute-stream": "~0.0.4"
@@ -9567,7 +8937,8 @@
 				},
 				"read-cmd-shim": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2"
@@ -9575,7 +8946,8 @@
 				},
 				"read-installed": {
 					"version": "4.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -9589,7 +8961,8 @@
 				},
 				"read-package-json": {
 					"version": "2.0.13",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.1",
@@ -9601,7 +8974,8 @@
 				},
 				"read-package-tree": {
 					"version": "5.2.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2CNoRoh95LxY47LvqrehIAfUVda2JbuFE/HaGYs42bNrGG+ojbw1h3zOcPcQ+1GQ3+rkzNndZn85u1XyZ3UsIA==",
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -9613,7 +8987,8 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -9627,7 +9002,8 @@
 				},
 				"readdir-scoped-modules": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
 					"dev": true,
 					"requires": {
 						"debuglog": "^1.0.1",
@@ -9638,7 +9014,8 @@
 				},
 				"registry-auth-token": {
 					"version": "3.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
 					"dev": true,
 					"requires": {
 						"rc": "^1.1.6",
@@ -9647,7 +9024,8 @@
 				},
 				"registry-url": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 					"dev": true,
 					"requires": {
 						"rc": "^1.0.1"
@@ -9655,7 +9033,8 @@
 				},
 				"request": {
 					"version": "2.88.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 					"dev": true,
 					"requires": {
 						"aws-sign2": "~0.7.0",
@@ -9682,27 +9061,32 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"resolve-from": {
 					"version": "4.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
 				"retry": {
 					"version": "0.12.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 					"dev": true
 				},
 				"rimraf": {
 					"version": "2.6.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"dev": true,
 					"requires": {
 						"glob": "^7.0.5"
@@ -9710,7 +9094,8 @@
 				},
 				"run-queue": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
@@ -9718,22 +9103,26 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true
 				},
 				"semver": {
 					"version": "5.5.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
 					"dev": true
 				},
 				"semver-diff": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 					"dev": true,
 					"requires": {
 						"semver": "^5.0.3"
@@ -9741,12 +9130,14 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"sha": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
@@ -9755,7 +9146,8 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -9763,32 +9155,38 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"slash": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
 					"dev": true
 				},
 				"slide": {
 					"version": "1.1.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
 					"dev": true
 				},
 				"smart-buffer": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-RFqinRVJVcCAL9Uh1oVqE6FZkqsyLiVOYEZ20TqIOjuX7iFVJ+zsbs4RIghnw/pTs7mZvt8ZHhvm1ZUrR4fykg==",
 					"dev": true
 				},
 				"socks": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-uRKV9uXQ9ytMbGm2+DilS1jB7N3AC0mmusmW5TVWjNuBZjxS8+lX38fasKVY9I4opv/bY/iqTbcpFFaTwpfwRg==",
 					"dev": true,
 					"requires": {
 						"ip": "^1.1.5",
@@ -9797,7 +9195,8 @@
 				},
 				"socks-proxy-agent": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Kezx6/VBguXOsEe5oU3lXYyKMi4+gva72TwJ7pQY5JfqUx2nMk7NXA6z/mpNqIlfQjWYVfeuNvQjexiTaTn6Nw==",
 					"dev": true,
 					"requires": {
 						"agent-base": "~4.2.0",
@@ -9806,12 +9205,14 @@
 				},
 				"sorted-object": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
 					"dev": true
 				},
 				"sorted-union-stream": {
 					"version": "2.1.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
 					"dev": true,
 					"requires": {
 						"from2": "^1.3.0",
@@ -9820,7 +9221,8 @@
 					"dependencies": {
 						"from2": {
 							"version": "1.3.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
 							"dev": true,
 							"requires": {
 								"inherits": "~2.0.1",
@@ -9829,12 +9231,14 @@
 						},
 						"isarray": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
 							"dev": true
 						},
 						"readable-stream": {
 							"version": "1.1.14",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 							"dev": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -9845,14 +9249,16 @@
 						},
 						"string_decoder": {
 							"version": "0.10.31",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
 							"dev": true
 						}
 					}
 				},
 				"spdx-correct": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 					"dev": true,
 					"requires": {
 						"spdx-expression-parse": "^3.0.0",
@@ -9861,12 +9267,14 @@
 				},
 				"spdx-exceptions": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
 					"dev": true
 				},
 				"spdx-expression-parse": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 					"dev": true,
 					"requires": {
 						"spdx-exceptions": "^2.1.0",
@@ -9875,12 +9283,14 @@
 				},
 				"spdx-license-ids": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
 					"dev": true
 				},
 				"sshpk": {
 					"version": "1.14.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
 					"dev": true,
 					"requires": {
 						"asn1": "~0.2.3",
@@ -9896,7 +9306,8 @@
 				},
 				"ssri": {
 					"version": "6.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
 					"dev": true,
 					"requires": {
 						"figgy-pudding": "^3.5.1"
@@ -9904,7 +9315,8 @@
 				},
 				"stream-each": {
 					"version": "1.2.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -9913,7 +9325,8 @@
 				},
 				"stream-iterate": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -9922,17 +9335,20 @@
 				},
 				"stream-shift": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
 					"dev": true
 				},
 				"strict-uri-encode": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
 						"is-fullwidth-code-point": "^2.0.0",
@@ -9941,17 +9357,20 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 							"dev": true
 						},
 						"strip-ansi": {
 							"version": "4.0.0",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^3.0.0"
@@ -9961,7 +9380,8 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.0"
@@ -9969,12 +9389,14 @@
 				},
 				"stringify-package": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
 					"dev": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -9982,17 +9404,20 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
@@ -10000,7 +9425,8 @@
 				},
 				"tar": {
 					"version": "4.4.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"dev": true,
 					"requires": {
 						"chownr": "^1.1.1",
@@ -10014,12 +9440,14 @@
 					"dependencies": {
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"dev": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -10028,14 +9456,16 @@
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"dev": true
 						}
 					}
 				},
 				"term-size": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0"
@@ -10043,17 +9473,20 @@
 				},
 				"text-table": {
 					"version": "0.2.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 					"dev": true
 				},
 				"through": {
 					"version": "2.3.8",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 					"dev": true
 				},
 				"through2": {
 					"version": "2.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 					"dev": true,
 					"requires": {
 						"readable-stream": "^2.1.5",
@@ -10062,17 +9495,20 @@
 				},
 				"timed-out": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
 					"dev": true
 				},
 				"tiny-relative-date": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==",
 					"dev": true
 				},
 				"tough-cookie": {
 					"version": "2.4.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 					"dev": true,
 					"requires": {
 						"psl": "^1.1.24",
@@ -10081,7 +9517,8 @@
 				},
 				"tunnel-agent": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -10089,28 +9526,33 @@
 				},
 				"tweetnacl": {
 					"version": "0.14.5",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 					"dev": true,
 					"optional": true
 				},
 				"typedarray": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
 					"dev": true
 				},
 				"uid-number": {
 					"version": "0.0.6",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 					"dev": true
 				},
 				"umask": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
 					"dev": true
 				},
 				"unique-filename": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
 					"dev": true,
 					"requires": {
 						"unique-slug": "^2.0.0"
@@ -10118,7 +9560,8 @@
 				},
 				"unique-slug": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -10126,7 +9569,8 @@
 				},
 				"unique-string": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 					"dev": true,
 					"requires": {
 						"crypto-random-string": "^1.0.0"
@@ -10134,17 +9578,20 @@
 				},
 				"unpipe": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
 					"dev": true
 				},
 				"unzip-response": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
 					"dev": true
 				},
 				"update-notifier": {
 					"version": "2.5.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
 					"dev": true,
 					"requires": {
 						"boxen": "^1.2.1",
@@ -10161,7 +9608,8 @@
 				},
 				"url-parse-lax": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 					"dev": true,
 					"requires": {
 						"prepend-http": "^1.0.1"
@@ -10169,22 +9617,26 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true
 				},
 				"util-extend": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
 					"dev": true
 				},
 				"uuid": {
 					"version": "3.3.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 					"dev": true
 				},
 				"validate-npm-package-license": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 					"dev": true,
 					"requires": {
 						"spdx-correct": "^3.0.0",
@@ -10193,7 +9645,8 @@
 				},
 				"validate-npm-package-name": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
 					"dev": true,
 					"requires": {
 						"builtins": "^1.0.3"
@@ -10201,7 +9654,8 @@
 				},
 				"verror": {
 					"version": "1.10.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 					"dev": true,
 					"requires": {
 						"assert-plus": "^1.0.0",
@@ -10211,7 +9665,8 @@
 				},
 				"wcwidth": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
 					"dev": true,
 					"requires": {
 						"defaults": "^1.0.3"
@@ -10219,7 +9674,8 @@
 				},
 				"which": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -10227,12 +9683,14 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"wide-align": {
 					"version": "1.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.2"
@@ -10240,7 +9698,8 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -10252,7 +9711,8 @@
 				},
 				"widest-line": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
 					"dev": true,
 					"requires": {
 						"string-width": "^2.1.1"
@@ -10260,7 +9720,8 @@
 				},
 				"worker-farm": {
 					"version": "1.6.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
 					"dev": true,
 					"requires": {
 						"errno": "~0.1.7"
@@ -10268,7 +9729,8 @@
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -10277,7 +9739,8 @@
 					"dependencies": {
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -10289,12 +9752,14 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"write-file-atomic": {
 					"version": "2.3.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"dev": true,
 					"requires": {
 						"graceful-fs": "^4.1.11",
@@ -10304,27 +9769,32 @@
 				},
 				"xdg-basedir": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
 					"dev": true
 				},
 				"xtend": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
 					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "11.0.0",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
@@ -10343,14 +9813,16 @@
 					"dependencies": {
 						"y18n": {
 							"version": "3.2.1",
-							"bundled": true,
+							"resolved": false,
+							"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 							"dev": true
 						}
 					}
 				},
 				"yargs-parser": {
 					"version": "9.0.2",
-					"bundled": true,
+					"resolved": false,
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -10362,7 +9834,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-			"dev": true,
 			"requires": {
 				"path-key": "^2.0.0"
 			}
@@ -10490,7 +9961,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -10646,8 +10116,7 @@
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-			"dev": true
+			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
 		},
 		"p-is-promise": {
 			"version": "2.0.0",
@@ -10692,8 +10161,7 @@
 		"p-try": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-			"dev": true
+			"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
 		},
 		"package-hash": {
 			"version": "2.0.0",
@@ -10805,8 +10273,7 @@
 		"path-key": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-			"dev": true
+			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
 			"version": "1.0.5",
@@ -10985,7 +10452,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -11196,19 +10662,7 @@
 				"camelcase": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 				},
 				"colors": {
 					"version": "1.3.3",
@@ -11220,7 +10674,6 @@
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
 						"path-key": "^2.0.1",
@@ -11233,7 +10686,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
 					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
 						"get-stream": "^4.0.0",
@@ -11248,7 +10700,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -11257,69 +10708,23 @@
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
 					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
-					}
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-					"dev": true
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
 					}
 				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
 					}
 				},
-				"mem": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-					"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^1.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-is-promise": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-					"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
-					"dev": true
-				},
 				"p-limit": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -11328,7 +10733,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
@@ -11336,38 +10740,7 @@
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 				}
 			}
 		},
@@ -11853,7 +11226,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"dev": true,
 			"requires": {
 				"shebang-regex": "^1.0.0"
 			}
@@ -11861,8 +11233,7 @@
 		"shebang-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-			"dev": true
+			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
 		},
 		"signal-exit": {
 			"version": "3.0.2",
@@ -12269,8 +11640,7 @@
 		"strip-eof": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-			"dev": true
+			"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
 		},
 		"strip-indent": {
 			"version": "2.0.0",
@@ -12484,19 +11854,7 @@
 				"camelcase": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-					"dev": true
-				},
-				"cliui": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-					"dev": true,
-					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
-					}
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -12530,7 +11888,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
 					}
@@ -12563,26 +11920,10 @@
 						"url-parse-lax": "^3.0.0"
 					}
 				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-					"dev": true
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
 					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
@@ -12594,39 +11935,10 @@
 					"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 					"dev": true
 				},
-				"mem": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-					"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^1.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-is-promise": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-					"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
-					"dev": true
-				},
 				"p-limit": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
 					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
-					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
@@ -12635,36 +11947,19 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
 					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
-					}
-				},
-				"p-retry": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-3.0.1.tgz",
-					"integrity": "sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==",
-					"dev": true,
-					"requires": {
-						"retry": "^0.12.0"
 					}
 				},
 				"path-exists": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 				},
 				"prepend-http": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
 					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
-					"dev": true
-				},
-				"retry": {
-					"version": "0.12.0",
-					"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-					"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
 					"dev": true
 				},
 				"url-parse-lax": {
@@ -12674,36 +11969,6 @@
 					"dev": true,
 					"requires": {
 						"prepend-http": "^2.0.0"
-					}
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -13000,7 +12265,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
 			}
@@ -13109,8 +12373,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "scripts": {
     "lint": "standard",
     "test": "ava --no-color test/*.js",
-    "semantic-release": "semantic-release",
-    "travis-deploy-once": "travis-deploy-once"
+    "semantic-release": "semantic-release"
   },
   "keywords": [
     "community",
@@ -45,8 +44,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "semantic-release": "^15.13.3",
-    "standard": "^12.0.1",
-    "travis-deploy-once": "^5.0.0"
+    "standard": "^12.0.1"
   },
   "engines": {
     "nodejs": ">=6.11.3"


### PR DESCRIPTION
Added the build stage (based off [this config](https://github.com/Berkmann18/TemplateJS/blob/master/.travis.yml)) and removed the unneeded `travis-deploy-once` (since it was deprecated in favour of TravisCI build stages).