### PR TITLE
feat(queries): added labels to `*Creators`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ jobs:
       script: skip
       deploy:
         provider: script
-        skip_cleanup: true,
+        skip_cleanup: true
         script: npm run semantic-release
 stages:
-  - test
+  - name: test
   - name: release
     if: branch = master

--- a/src/queries.js
+++ b/src/queries.js
@@ -57,8 +57,7 @@ const repoSubQuery = (before = new Date(), after, commits, reactionsInQuery) => 
   const masterCommits = node('ref', { qualifiedName: 'refs/heads/master' }, [
     typeSwitch('target', {}, [
       ['Commit', [
-        edge('history', { since: a, until: b },
-          [commitAuthorQ, val('committedDate')])
+        edge('history', { since: a, until: b }, [commitAuthorQ, val('committedDate')])
       ]]
     ])
   ])
@@ -174,7 +173,7 @@ const mergeContributions = xs => {
 const mergeExtendedContributions = xs => {
   // Get rid of null authors
   let usrs = xs.filter(x => x.author != null || x.user != null)
-  xs.forEach(x => { 
+  xs.forEach(x => {
     if (!('count' in x)) {
       x.count = 1
     }
@@ -182,8 +181,8 @@ const mergeExtendedContributions = xs => {
   const m = new Map()
   for (let x of usrs) {
     // Use GitHub login as unique key.
-    let key = x.author.login
-    let labels = x.labels.nodes.map(label => label.name)
+    const key = x.author.login
+    const labels = x.labels.nodes.map(label => label.name)
     if (m.has(key)) {
       let p = m.get(key)
 
@@ -221,6 +220,7 @@ const repoSynopsis = ({ json, before, after, commits, reactions }) => {
   const process = x => mergeContributions(users(tf(x)))
     .sort(byCount)
   const extendedProcess = x => mergeExtendedContributions(tf(x))
+    .sort(byCount)
 
   const repo = json.repository
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -174,7 +174,11 @@ const mergeContributions = xs => {
 const mergeExtendedContributions = xs => {
   // Get rid of null authors
   let usrs = xs.filter(x => x.author != null || x.user != null)
-  xs.forEach(x => { x.count = 1 })
+  xs.forEach(x => { 
+    if (!('count' in x)) {
+      x.count = 1
+    }
+  })
   const m = new Map()
   for (let x of usrs) {
     // Use GitHub login as unique key.
@@ -389,6 +393,7 @@ module.exports = {
   users,
   repoSynopsis,
   mergeContributions,
+  mergeExtendedContributions,
   mergeArrays,
   mergeRepoResults,
   authoredQ

--- a/test/queries-test.js
+++ b/test/queries-test.js
@@ -56,6 +56,19 @@ test('merge', t => {
   ])
 })
 
+test('extended merge', t => {
+  const testusers = [{ author: { login: 'x', name: 'x', url: 'x' }, count: 1, labels: { nodes: [{ name: 'a' }] } },
+    { author: { login: 'y', name: 'x', url: 'x' }, count: 1, labels: { nodes: []} },
+    { author: { login: 'x', name: 'x', url: 'x' }, count: 3, labels: { nodes: [{ name: 'b' }] } },
+    { author: { login: 'z', name: 'x', url: 'x' }, count: 2, labels: { nodes: [{ name: 'c' }] } }]
+
+  t.deepEqual(q.mergeExtendedContributions(testusers), [
+    { login: 'x', count: 4, name: 'x', url: 'x', email: undefined, labels: ['a', 'b'] },
+    { login: 'y', count: 1, name: 'x', url: 'x', email: undefined, labels: [] },
+    { login: 'z', count: 2, name: 'x', url: 'x', email: undefined, labels: ['c'] }
+  ])
+})
+
 test('null users get filtered', t => {
   const ulist = [{ author: { login: 'me', name: 'just me' } }, { author: null }]
   t.deepEqual(q.users(ulist), [{ login: 'me', name: 'just me', count: 1 }])

--- a/test/queries-test.js
+++ b/test/queries-test.js
@@ -58,7 +58,7 @@ test('merge', t => {
 
 test('extended merge', t => {
   const testusers = [{ author: { login: 'x', name: 'x', url: 'x' }, count: 1, labels: { nodes: [{ name: 'a' }] } },
-    { author: { login: 'y', name: 'x', url: 'x' }, count: 1, labels: { nodes: []} },
+    { author: { login: 'y', name: 'x', url: 'x' }, count: 1, labels: { nodes: [] } },
     { author: { login: 'x', name: 'x', url: 'x' }, count: 3, labels: { nodes: [{ name: 'b' }] } },
     { author: { login: 'z', name: 'x', url: 'x' }, count: 2, labels: { nodes: [{ name: 'c' }] } }]
 


### PR DESCRIPTION
The objects in `prCreators` and `issueCreators` now have an additional `labels` field exposing the labels of the relevant PRs/issues associated with a contributor.

re https://github.com/mntnr/name-your-contributors/issues/73#issuecomment-464128386 and https://github.com/mntnr/name-your-contributors/issues/45#issuecomment-464112417.