### PR TITLE
fix(queries): fixed typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 config.json
 data
 cache
+examples

--- a/src/queries.js
+++ b/src/queries.js
@@ -352,7 +352,7 @@ const filterRepo = (json, before, after) => {
   repo.pullRequests = prs
 
   if (repo.commitComments) {
-    repo.commitcomments = commitComments
+    repo.commitComments = commitComments
   }
 
   return json


### PR DESCRIPTION
Fixed the case typo in queries.js and added `./examples` to the ignore list.

fix #98 