### PR TITLE
Semantic Release plugins

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+    ["@semantic-release/git", {
+      "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+    }],
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,12 +85,6 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
 				}
 			}
 		},
@@ -105,14 +99,6 @@
 				"lodash": "^4.17.10",
 				"source-map": "^0.5.0",
 				"trim-right": "^1.0.1"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
@@ -185,14 +171,6 @@
 				"@babel/template": "^7.2.2",
 				"@babel/types": "^7.2.2",
 				"lodash": "^4.17.10"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -208,14 +186,6 @@
 			"dev": true,
 			"requires": {
 				"lodash": "^4.17.10"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -435,12 +405,6 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
-				},
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
 				}
 			}
 		},
@@ -453,14 +417,6 @@
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.10",
 				"to-fast-properties": "^2.0.0"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.11",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-					"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-					"dev": true
-				}
 			}
 		},
 		"@concordance/react": {
@@ -559,6 +515,120 @@
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
 			"integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
 			"dev": true
+		},
+		"@semantic-release/git": {
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-7.0.8.tgz",
+			"integrity": "sha512-sA+XoPU6GrV+A4YswO0b5JWL1KbzmyyaqUK6Y2poDkIVPlj+oQdi/stpKz/bKF5z9ChMGP87OVPMeUyXGaNFtw==",
+			"dev": true,
+			"requires": {
+				"@semantic-release/error": "^2.1.0",
+				"aggregate-error": "^2.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^2.0.0",
+				"execa": "^1.0.0",
+				"fs-extra": "^7.0.0",
+				"globby": "^9.0.0",
+				"lodash": "^4.17.4",
+				"micromatch": "^3.1.4",
+				"p-reduce": "^1.0.0"
+			},
+			"dependencies": {
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"execa": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^6.0.0",
+						"get-stream": "^4.0.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globby": {
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+					"dev": true,
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^1.0.2",
+						"dir-glob": "^2.2.2",
+						"fast-glob": "^2.2.6",
+						"glob": "^7.1.3",
+						"ignore": "^4.0.3",
+						"pify": "^4.0.1",
+						"slash": "^2.0.0"
+					}
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+					"dev": true
+				},
+				"slash": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+					"dev": true
+				}
+			}
 		},
 		"@semantic-release/github": {
 			"version": "5.2.10",
@@ -749,6 +819,35 @@
 				}
 			}
 		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+			"dev": true
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"dev": true,
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.13.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.4.tgz",
+			"integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==",
+			"dev": true
+		},
 		"JSONStream": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -758,6 +857,18 @@
 				"jsonparse": "^1.2.0",
 				"through": ">=2.2.7 <3"
 			}
+		},
+		"acorn": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+			"integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+			"dev": true
+		},
+		"acorn-jsx": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+			"dev": true
 		},
 		"agent-base": {
 			"version": "4.2.1",
@@ -777,6 +888,24 @@
 				"clean-stack": "^2.0.0",
 				"indent-string": "^3.0.0"
 			}
+		},
+		"ajv": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+			"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+			"dev": true,
+			"requires": {
+				"fast-deep-equal": "^2.0.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			}
+		},
+		"ajv-keywords": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"dev": true
 		},
 		"ansi-align": {
 			"version": "2.0.0",
@@ -931,6 +1060,12 @@
 			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
 			"dev": true
 		},
+		"atob": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
 		"ava": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/ava/-/ava-1.0.1.tgz",
@@ -1049,12 +1184,6 @@
 						"supports-color": "^5.3.0"
 					}
 				},
-				"clean-stack": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.0.0.tgz",
-					"integrity": "sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==",
-					"dev": true
-				},
 				"debug": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
@@ -1062,43 +1191,6 @@
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
-					}
-				},
-				"del": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"dev": true,
-					"requires": {
-						"globby": "^6.1.0",
-						"is-path-cwd": "^1.0.0",
-						"is-path-in-cwd": "^1.0.0",
-						"p-map": "^1.1.1",
-						"pify": "^3.0.0",
-						"rimraf": "^2.2.8"
-					},
-					"dependencies": {
-						"globby": {
-							"version": "6.1.0",
-							"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-							"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-							"dev": true,
-							"requires": {
-								"array-union": "^1.0.1",
-								"glob": "^7.0.3",
-								"object-assign": "^4.0.1",
-								"pify": "^2.0.0",
-								"pinkie-promise": "^2.0.0"
-							},
-							"dependencies": {
-								"pify": {
-									"version": "2.3.0",
-									"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-									"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-									"dev": true
-								}
-							}
-						}
 					}
 				},
 				"find-up": {
@@ -1154,12 +1246,6 @@
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
 				},
 				"slash": {
 					"version": "2.0.0",
@@ -1317,12 +1403,6 @@
 						"kind-of": "^6.0.2"
 					}
 				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -1441,14 +1521,6 @@
 				"to-object-path": "^0.3.0",
 				"union-value": "^1.0.0",
 				"unset-value": "^1.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"call-matcher": {
@@ -1620,12 +1692,6 @@
 					"requires": {
 						"is-descriptor": "^0.1.0"
 					}
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
 				}
 			}
 		},
@@ -2146,12 +2212,6 @@
 						"kind-of": "^6.0.2"
 					}
 				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2172,6 +2232,43 @@
 				"pkg-config": "^1.1.0",
 				"run-parallel": "^1.1.2",
 				"uniq": "^1.0.1"
+			}
+		},
+		"del": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"dev": true,
+			"requires": {
+				"globby": "^6.1.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"p-map": "^1.1.1",
+				"pify": "^3.0.0",
+				"rimraf": "^2.2.8"
+			},
+			"dependencies": {
+				"globby": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+					"dev": true,
+					"requires": {
+						"array-union": "^1.0.1",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
+					},
+					"dependencies": {
+						"pify": {
+							"version": "2.3.0",
+							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+							"dev": true
+						}
+					}
+				}
 			}
 		},
 		"dir-glob": {
@@ -2408,18 +2505,6 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
-				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2432,12 +2517,6 @@
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
 					}
-				},
-				"globals": {
-					"version": "11.10.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-					"integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
-					"dev": true
 				},
 				"ignore": {
 					"version": "4.0.6",
@@ -2745,20 +2824,6 @@
 				"acorn": "^6.0.2",
 				"acorn-jsx": "^5.0.0",
 				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-					"integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
-					"dev": true
-				},
-				"acorn-jsx": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-					"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
-					"dev": true
-				}
 			}
 		},
 		"esprima": {
@@ -2863,62 +2928,10 @@
 						"is-extendable": "^0.1.0"
 					}
 				},
-				"is-accessor-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-					"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-data-descriptor": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-					"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
-				"is-descriptor": {
-					"version": "0.1.6",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-					"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-					"dev": true,
-					"requires": {
-						"is-accessor-descriptor": "^0.1.6",
-						"is-data-descriptor": "^0.1.4",
-						"kind-of": "^5.0.0"
-					}
-				},
 				"kind-of": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-					"dev": true
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
 				},
 				"ms": {
 					"version": "2.0.0",
@@ -3198,9 +3211,9 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+			"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -3227,7 +3240,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3253,7 +3266,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3292,7 +3305,7 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3341,7 +3354,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3361,12 +3374,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -3431,17 +3444,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3460,13 +3473,12 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": false,
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3477,18 +3489,18 @@
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.10.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -3505,13 +3517,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -3588,12 +3600,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -3623,16 +3635,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3650,7 +3662,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3703,17 +3715,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -3724,12 +3736,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -3739,7 +3751,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3768,6 +3780,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.0.0.tgz",
 			"integrity": "sha512-Yy3yNI2oShgbaWg4cmPhWjkZfktEvpKI09aDX4PZzNtlU9obuYrX7x2mumQsrNxlF+Ls7OtMQW/u+X4s896bOQ==",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
 			"dev": true
 		},
 		"get-stream": {
@@ -3966,14 +3984,6 @@
 				"get-value": "^2.0.6",
 				"has-values": "^1.0.0",
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"has-values": {
@@ -3986,26 +3996,6 @@
 				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
-				},
 				"kind-of": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -4397,14 +4387,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"is-promise": {
@@ -4664,13 +4646,6 @@
 			"requires": {
 				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-				}
 			}
 		},
 		"lodash": {
@@ -5120,9 +5095,9 @@
 			"dev": true
 		},
 		"nan": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-			"integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
 			"dev": true,
 			"optional": true
 		},
@@ -5145,18 +5120,6 @@
 				"to-regex": "^3.0.1"
 			},
 			"dependencies": {
-				"arr-diff": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-					"dev": true
-				},
-				"array-unique": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -5243,9 +5206,9 @@
 			}
 		},
 		"normalize-url": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.1.0.tgz",
-			"integrity": "sha512-X781mkWeK6PDMAZJfGn/wnwil4dV6pIdF9euiNqtA89uJvZuNDJO2YyJxiwpPhTQcF5pYUU1v+kcOxzYV6rZlA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
+			"integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==",
 			"dev": true
 		},
 		"npm": {
@@ -8404,14 +8367,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.0"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"object.pick": {
@@ -8421,14 +8376,6 @@
 			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
-			},
-			"dependencies": {
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				}
 			}
 		},
 		"observable-to-promise": {
@@ -8731,8 +8678,7 @@
 		"path-exists": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-			"dev": true
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -8861,12 +8807,6 @@
 					"requires": {
 						"p-limit": "^2.0.0"
 					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
 				}
 			}
 		},
@@ -9684,12 +9624,6 @@
 						"kind-of": "^6.0.2"
 					}
 				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-					"dev": true
-				},
 				"kind-of": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -9724,14 +9658,6 @@
 				"resolve-url": "^0.2.1",
 				"source-map-url": "^0.4.0",
 				"urix": "^0.1.0"
-			},
-			"dependencies": {
-				"atob": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-					"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-					"dev": true
-				}
 			}
 		},
 		"source-map-support": {
@@ -9858,14 +9784,6 @@
 				"get-stdin": "^6.0.0",
 				"minimist": "^1.1.0",
 				"pkg-conf": "^2.0.0"
-			},
-			"dependencies": {
-				"get-stdin": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-					"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-					"dev": true
-				}
 			}
 		},
 		"static-extend": {
@@ -9986,14 +9904,6 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
-			},
-			"dependencies": {
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				}
 			}
 		},
 		"supports-hyperlinks": {
@@ -10032,26 +9942,6 @@
 				"lodash": "^4.17.4",
 				"slice-ansi": "1.0.0",
 				"string-width": "^2.1.1"
-			},
-			"dependencies": {
-				"ajv": {
-					"version": "6.9.1",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
-					"integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
-					"dev": true,
-					"requires": {
-						"fast-deep-equal": "^2.0.1",
-						"fast-json-stable-stringify": "^2.0.0",
-						"json-schema-traverse": "^0.4.1",
-						"uri-js": "^4.2.2"
-					}
-				},
-				"ajv-keywords": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-					"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-					"dev": true
-				}
 			}
 		},
 		"term-size": {
@@ -10173,17 +10063,6 @@
 			"requires": {
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				}
 			}
 		},
 		"traverse": {
@@ -10384,12 +10263,6 @@
 					"version": "0.1.4",
 					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
 					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -445,9 +445,9 @@
 			"dev": true
 		},
 		"@octokit/endpoint": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-			"integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-4.0.0.tgz",
+			"integrity": "sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==",
 			"dev": true,
 			"requires": {
 				"deepmerge": "3.2.0",
@@ -457,30 +457,35 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.3.0.tgz",
-			"integrity": "sha512-5YRqYNZOAaL7+nt7w3Scp6Sz4P2g7wKFP9npx1xdExMomk8/M/ICXVLYVam2wzxeY0cIc6wcKpjC5KI4jiNbGw==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-3.0.0.tgz",
+			"integrity": "sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^3.1.1",
+				"@octokit/endpoint": "^4.0.0",
+				"deprecation": "^1.0.1",
 				"is-plain-object": "^2.0.4",
 				"node-fetch": "^2.3.0",
+				"once": "^1.4.0",
 				"universal-user-agent": "^2.0.1"
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.16.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.16.0.tgz",
-			"integrity": "sha512-Q6L5OwQJrdJ188gLVmUHLKNXBoeCU0DynKPYW8iZQQoGNGws2hkP/CePVNlzzDgmjuv7o8dCrJgecvDcIHccTA==",
+			"version": "16.24.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.24.1.tgz",
+			"integrity": "sha512-V2GVL+cfuwNTcZ9qtBMOR9pIftWo1AiZIiGvWNmTcIQG5mkj83ZXC+g3w5g0cVXt7Hi+mSOrD2bZ7HJOuouUNg==",
 			"dev": true,
 			"requires": {
-				"@octokit/request": "2.3.0",
-				"before-after-hook": "^1.2.0",
+				"@octokit/request": "3.0.0",
+				"atob-lite": "^2.0.0",
+				"before-after-hook": "^1.4.0",
 				"btoa-lite": "^1.0.0",
+				"deprecation": "^1.0.1",
 				"lodash.get": "^4.4.2",
 				"lodash.set": "^4.3.2",
 				"lodash.uniq": "^4.5.0",
 				"octokit-pagination-methods": "^1.1.0",
+				"once": "^1.4.0",
 				"universal-user-agent": "^2.0.0",
 				"url-template": "^2.0.8"
 			}
@@ -679,13 +684,14 @@
 					}
 				},
 				"globby": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-9.0.0.tgz",
-					"integrity": "sha512-q0qiO/p1w/yJ0hk8V9x1UXlgsXUxlGd0AHUOXZVXBO6aznDtpx7M8D1kBrCAItoPm+4l8r6ATXV1JpjY2SBQOw==",
+					"version": "9.2.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+					"integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
 					"dev": true,
 					"requires": {
+						"@types/glob": "^7.1.1",
 						"array-union": "^1.0.2",
-						"dir-glob": "^2.2.1",
+						"dir-glob": "^2.2.2",
 						"fast-glob": "^2.2.6",
 						"glob": "^7.1.3",
 						"ignore": "^4.0.3",
@@ -714,24 +720,34 @@
 			}
 		},
 		"@semantic-release/npm": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.4.tgz",
-			"integrity": "sha512-YRl8VTVwnRTl/sVRvTXs1ncYcuvuGrqPEXYy+lUK1YRLq25hkrhIdv3Ju0u1zGLqVCA8qRlF3NzWl7pULJXVog==",
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-5.1.7.tgz",
+			"integrity": "sha512-4THiFGp9APX1a+EJJsOYurJCR8TrRUgNCU9u46AkZekWfvtyzacfIBKCrmEljpYG8qDDnHLZwHSqyW4ID4iteA==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/error": "^2.2.0",
-				"aggregate-error": "^2.0.0",
+				"aggregate-error": "^3.0.0",
 				"execa": "^1.0.0",
 				"fs-extra": "^7.0.0",
 				"lodash": "^4.17.4",
 				"nerf-dart": "^1.0.0",
 				"normalize-url": "^4.0.0",
-				"npm": "6.5.0",
+				"npm": "^6.8.0",
 				"rc": "^1.2.8",
-				"read-pkg": "^4.0.0",
+				"read-pkg": "^5.0.0",
 				"registry-auth-token": "^3.3.1"
 			},
 			"dependencies": {
+				"aggregate-error": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.0.tgz",
+					"integrity": "sha512-yKD9kEoJIR+2IFqhMwayIBgheLYbB3PS2OBhWae1L/ODTd/JF/30cW0bc9TqzRL3k4U41Dieu3BF4I29p8xesA==",
+					"dev": true,
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^3.2.0"
+					}
+				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -770,14 +786,13 @@
 					}
 				},
 				"read-pkg": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
-					"integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.0.0.tgz",
+					"integrity": "sha512-OWufaRc67oJjcgrxckW/qO9q22iYzyiONh8h+GMcnOvSHAmhV1Dr3x+gyRjP+Qxc5jKupkSfoCQLS/98rDPh9A==",
 					"dev": true,
 					"requires": {
 						"normalize-package-data": "^2.3.2",
-						"parse-json": "^4.0.0",
-						"pify": "^3.0.0"
+						"parse-json": "^4.0.0"
 					}
 				}
 			}
@@ -1045,15 +1060,6 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
-		"async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.11"
-			}
-		},
 		"async-each": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -1064,6 +1070,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
 			"dev": true
 		},
 		"ava": {
@@ -1412,9 +1424,9 @@
 			}
 		},
 		"before-after-hook": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-			"integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+			"integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==",
 			"dev": true
 		},
 		"binary-extensions": {
@@ -1430,9 +1442,9 @@
 			"dev": true
 		},
 		"bottleneck": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.16.2.tgz",
-			"integrity": "sha512-671wkIKV9K3yO/nfGw8tB4ihJazmZyd6DYEWxF1fuE7gzobk4w4atepHuYXoUHk78xLknjAGko8dXRcFO7iCoA==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.18.0.tgz",
+			"integrity": "sha512-U1xiBRaokw4yEguzikOl0VrnZp6uekjpmfrh6rKtr1D+/jFjYCL6J83ZXlGtlBDwVdTmJJ+4Lg5FpB3xmLSiyA==",
 			"dev": true
 		},
 		"boxen": {
@@ -1817,9 +1829,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "2.17.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-			"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -2002,15 +2014,14 @@
 			"dev": true
 		},
 		"cosmiconfig": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-			"integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+			"integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
 			"dev": true,
 			"requires": {
 				"import-fresh": "^2.0.0",
 				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"lodash.get": "^4.4.2",
+				"js-yaml": "^3.13.0",
 				"parse-json": "^4.0.0"
 			}
 		},
@@ -2270,6 +2281,12 @@
 					}
 				}
 			}
+		},
+		"deprecation": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+			"integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==",
+			"dev": true
 		},
 		"dir-glob": {
 			"version": "2.2.2",
@@ -2827,9 +2844,9 @@
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
 		},
 		"espurify": {
@@ -3149,9 +3166,9 @@
 			},
 			"dependencies": {
 				"array-uniq": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-					"integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.1.0.tgz",
+					"integrity": "sha512-bdHxtev7FN6+MXI1YFW0Q8mQ8dTJc2S8AMfju+ZR77pbg2yAdVyDlwkaUI7Har0LyOMRFPHrJ9lYdyjZZswdlQ==",
 					"dev": true
 				}
 			}
@@ -3771,9 +3788,9 @@
 			"dev": true
 		},
 		"get-caller-file": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.1.tgz",
-			"integrity": "sha512-SpOZHfz845AH0wJYVuZk2jWDqFmu7Xubsx+ldIpwzy5pDUpu7OJHK7QYNSA2NPlDSKQwM1GFaAkciOWjjW92Sg==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
 		"get-port": {
@@ -3926,12 +3943,12 @@
 			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
 		},
 		"handlebars": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-			"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"dev": true,
 			"requires": {
-				"async": "^2.5.0",
+				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
 				"uglify-js": "^3.1.4"
@@ -4008,9 +4025,9 @@
 			}
 		},
 		"hook-std": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-1.2.0.tgz",
-			"integrity": "sha512-yntre2dbOAjgQ5yoRykyON0D9T96BfshR8IuiL/r3celeHD8I/76w4qo8m3z99houR4Z678jakV3uXrQdSvW/w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
+			"integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
 			"dev": true
 		},
 		"hosted-git-info": {
@@ -4520,9 +4537,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -4818,9 +4835,9 @@
 			}
 		},
 		"macos-release": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-			"integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+			"integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA==",
 			"dev": true
 		},
 		"make-dir": {
@@ -4862,9 +4879,9 @@
 			}
 		},
 		"marked": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
-			"integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+			"integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==",
 			"dev": true
 		},
 		"marked-terminal": {
@@ -4925,14 +4942,22 @@
 			"dev": true
 		},
 		"mem": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-			"integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+			"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 			"dev": true,
 			"requires": {
 				"map-age-cleaner": "^0.1.1",
-				"mimic-fn": "^1.0.0",
+				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
+			},
+			"dependencies": {
+				"mimic-fn": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"dev": true
+				}
 			}
 		},
 		"meow": {
@@ -4987,9 +5012,9 @@
 			}
 		},
 		"mime": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
-			"integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+			"integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
 			"dev": true
 		},
 		"mimic-fn": {
@@ -5134,6 +5159,12 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
+		"neo-async": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+			"integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+			"dev": true
+		},
 		"nerf-dart": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
@@ -5212,26 +5243,26 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-6.5.0.tgz",
-			"integrity": "sha512-SPq8zG2Kto+Xrq55E97O14Jla13PmQT5kSnvwBj88BmJZ5Nvw++OmlWfhjkB67pcgP5UEXljEtnGFKZtOgt6MQ==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-6.9.0.tgz",
+			"integrity": "sha512-91V+zB5hDxO+Jyp2sUKS7juHlIM95dGQxTeQtmZI1nAI/7kjWXFipPrtwwKjhyKmV4GsS2LzJhrxRjGWsU9z/w==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "^1.3.4",
+				"JSONStream": "^1.3.5",
 				"abbrev": "~1.1.1",
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
-				"aproba": "~1.2.0",
+				"aproba": "^2.0.0",
 				"archy": "~1.0.0",
 				"bin-links": "^1.1.2",
 				"bluebird": "^3.5.3",
-				"byte-size": "^4.0.3",
-				"cacache": "^11.2.0",
+				"byte-size": "^5.0.1",
+				"cacache": "^11.3.2",
 				"call-limit": "~1.1.0",
-				"chownr": "~1.0.1",
-				"ci-info": "^1.6.0",
+				"chownr": "^1.1.1",
+				"ci-info": "^2.0.0",
 				"cli-columns": "^3.1.2",
-				"cli-table3": "^0.5.0",
+				"cli-table3": "^0.5.1",
 				"cmd-shim": "~2.0.2",
 				"columnify": "~1.5.4",
 				"config-chain": "^1.1.12",
@@ -5255,13 +5286,18 @@
 				"inherits": "~2.0.3",
 				"ini": "^1.3.5",
 				"init-package-json": "^1.10.3",
-				"is-cidr": "^2.0.6",
+				"is-cidr": "^3.0.0",
 				"json-parse-better-errors": "^1.0.2",
 				"lazy-property": "~1.0.0",
-				"libcipm": "^2.0.2",
-				"libnpmhook": "^4.0.1",
+				"libcipm": "^3.0.3",
+				"libnpm": "^2.0.1",
+				"libnpmaccess": "*",
+				"libnpmhook": "^5.0.2",
+				"libnpmorg": "*",
+				"libnpmsearch": "*",
+				"libnpmteam": "*",
 				"libnpx": "^10.2.0",
-				"lock-verify": "^2.0.2",
+				"lock-verify": "^2.1.0",
 				"lockfile": "^1.0.4",
 				"lodash._baseindexof": "*",
 				"lodash._baseuniq": "~4.6.0",
@@ -5274,47 +5310,46 @@
 				"lodash.union": "~4.6.0",
 				"lodash.uniq": "~4.5.0",
 				"lodash.without": "~4.4.0",
-				"lru-cache": "^4.1.3",
+				"lru-cache": "^4.1.5",
 				"meant": "~1.0.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "~0.5.1",
 				"move-concurrently": "^1.0.1",
 				"node-gyp": "^3.8.0",
 				"nopt": "~4.0.1",
-				"normalize-package-data": "~2.4.0",
-				"npm-audit-report": "^1.3.1",
+				"normalize-package-data": "^2.5.0",
+				"npm-audit-report": "^1.3.2",
 				"npm-cache-filename": "~1.0.2",
 				"npm-install-checks": "~3.0.0",
 				"npm-lifecycle": "^2.1.0",
 				"npm-package-arg": "^6.1.0",
-				"npm-packlist": "^1.1.12",
-				"npm-pick-manifest": "^2.1.0",
-				"npm-profile": "^3.0.2",
-				"npm-registry-client": "^8.6.0",
-				"npm-registry-fetch": "^1.1.0",
+				"npm-packlist": "^1.4.1",
+				"npm-pick-manifest": "^2.2.3",
+				"npm-profile": "*",
+				"npm-registry-fetch": "^3.9.0",
 				"npm-user-validate": "~1.0.0",
 				"npmlog": "~4.1.2",
 				"once": "~1.4.0",
 				"opener": "^1.5.1",
 				"osenv": "^0.1.5",
-				"pacote": "^8.1.6",
+				"pacote": "^9.5.0",
 				"path-is-inside": "~1.0.2",
 				"promise-inflight": "~1.0.1",
 				"qrcode-terminal": "^0.12.0",
-				"query-string": "^6.1.0",
+				"query-string": "^6.2.0",
 				"qw": "~1.0.1",
 				"read": "~1.0.7",
 				"read-cmd-shim": "~1.0.1",
 				"read-installed": "~4.0.3",
 				"read-package-json": "^2.0.13",
-				"read-package-tree": "^5.2.1",
-				"readable-stream": "^2.3.6",
+				"read-package-tree": "^5.2.2",
+				"readable-stream": "^3.1.1",
 				"readdir-scoped-modules": "*",
 				"request": "^2.88.0",
 				"retry": "^0.12.0",
-				"rimraf": "~2.6.2",
+				"rimraf": "^2.6.3",
 				"safe-buffer": "^5.1.2",
-				"semver": "^5.5.1",
+				"semver": "^5.6.0",
 				"sha": "~2.0.1",
 				"slide": "~1.1.6",
 				"sorted-object": "~2.0.1",
@@ -5326,7 +5361,7 @@
 				"tiny-relative-date": "^1.3.0",
 				"uid-number": "0.0.6",
 				"umask": "~1.1.0",
-				"unique-filename": "~1.1.0",
+				"unique-filename": "^1.1.1",
 				"unpipe": "~1.0.0",
 				"update-notifier": "^2.5.0",
 				"uuid": "^3.3.2",
@@ -5334,11 +5369,11 @@
 				"validate-npm-package-name": "~3.0.0",
 				"which": "^1.3.1",
 				"worker-farm": "^1.6.0",
-				"write-file-atomic": "^2.3.0"
+				"write-file-atomic": "^2.4.2"
 			},
 			"dependencies": {
 				"JSONStream": {
-					"version": "1.3.4",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -5352,7 +5387,7 @@
 					"dev": true
 				},
 				"agent-base": {
-					"version": "4.2.0",
+					"version": "4.2.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -5410,7 +5445,7 @@
 					"dev": true
 				},
 				"aproba": {
-					"version": "1.2.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -5426,6 +5461,30 @@
 					"requires": {
 						"delegates": "^1.0.0",
 						"readable-stream": "^2.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"asap": {
@@ -5528,11 +5587,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"builtin-modules": {
-					"version": "1.1.1",
-					"bundled": true,
-					"dev": true
-				},
 				"builtins": {
 					"version": "1.0.3",
 					"bundled": true,
@@ -5544,29 +5598,57 @@
 					"dev": true
 				},
 				"byte-size": {
-					"version": "4.0.3",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"cacache": {
-					"version": "11.2.0",
+					"version": "11.3.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"chownr": "^1.0.1",
-						"figgy-pudding": "^3.1.0",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.3",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"move-concurrently": "^1.0.1",
 						"promise-inflight": "^1.0.1",
 						"rimraf": "^2.6.2",
-						"ssri": "^6.0.0",
-						"unique-filename": "^1.1.0",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
 						"y18n": "^4.0.0"
+					},
+					"dependencies": {
+						"chownr": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true
+						},
+						"lru-cache": {
+							"version": "5.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"yallist": "^3.0.2"
+							}
+						},
+						"unique-filename": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"unique-slug": "^2.0.0"
+							}
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"call-limit": {
@@ -5600,17 +5682,17 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true
 				},
 				"ci-info": {
-					"version": "1.6.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"cidr-regex": {
-					"version": "2.0.9",
+					"version": "2.0.10",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -5632,7 +5714,7 @@
 					}
 				},
 				"cli-table3": {
-					"version": "0.5.0",
+					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -5704,7 +5786,7 @@
 					"dev": true
 				},
 				"colors": {
-					"version": "1.1.2",
+					"version": "1.3.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -5740,6 +5822,30 @@
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.2.2",
 						"typedarray": "^0.0.6"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"config-chain": {
@@ -5782,6 +5888,11 @@
 						"run-queue": "^1.0.0"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"iferr": {
 							"version": "0.1.5",
 							"bundled": true,
@@ -5929,6 +6040,30 @@
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"ecc-jsbn": {
@@ -5976,7 +6111,7 @@
 					}
 				},
 				"es6-promise": {
-					"version": "4.2.4",
+					"version": "4.2.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -6005,6 +6140,13 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"extend": {
@@ -6052,6 +6194,30 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.4"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"forever-agent": {
@@ -6076,6 +6242,30 @@
 					"requires": {
 						"inherits": "^2.0.1",
 						"readable-stream": "^2.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"fs-minipass": {
@@ -6111,6 +6301,28 @@
 							"version": "0.1.5",
 							"bundled": true,
 							"dev": true
+						},
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
 						}
 					}
 				},
@@ -6145,6 +6357,11 @@
 						"wide-align": "^1.1.0"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
@@ -6158,7 +6375,7 @@
 					}
 				},
 				"genfun": {
-					"version": "4.0.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -6177,6 +6394,11 @@
 						"slide": "^1.1.6"
 					},
 					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"iferr": {
 							"version": "0.1.5",
 							"bundled": true,
@@ -6190,9 +6412,12 @@
 					"dev": true
 				},
 				"get-stream": {
-					"version": "3.0.0",
+					"version": "4.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
+					}
 				},
 				"getpass": {
 					"version": "0.1.7",
@@ -6239,6 +6464,13 @@
 						"timed-out": "^4.0.0",
 						"unzip-response": "^2.0.1",
 						"url-parse-lax": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"graceful-fs": {
@@ -6396,28 +6628,27 @@
 					"bundled": true,
 					"dev": true
 				},
-				"is-builtin-module": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"builtin-modules": "^1.0.0"
-					}
-				},
 				"is-ci": {
 					"version": "1.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ci-info": "^1.0.0"
+					},
+					"dependencies": {
+						"ci-info": {
+							"version": "1.6.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"is-cidr": {
-					"version": "2.0.6",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cidr-regex": "^2.0.8"
+						"cidr-regex": "^2.0.10"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -6554,46 +6785,192 @@
 					}
 				},
 				"libcipm": {
-					"version": "2.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"bin-links": "^1.1.2",
 						"bluebird": "^3.5.1",
+						"figgy-pudding": "^3.5.1",
 						"find-npm-prefix": "^1.0.2",
 						"graceful-fs": "^4.1.11",
+						"ini": "^1.3.5",
 						"lock-verify": "^2.0.2",
 						"mkdirp": "^0.5.1",
 						"npm-lifecycle": "^2.0.3",
 						"npm-logical-tree": "^1.2.1",
 						"npm-package-arg": "^6.1.0",
-						"pacote": "^8.1.6",
-						"protoduck": "^5.0.0",
+						"pacote": "^9.1.0",
 						"read-package-json": "^2.0.13",
 						"rimraf": "^2.6.2",
 						"worker-farm": "^1.6.0"
 					}
 				},
-				"libnpmhook": {
-					"version": "4.0.1",
+				"libnpm": {
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"figgy-pudding": "^3.1.0",
-						"npm-registry-fetch": "^3.0.0"
+						"bin-links": "^1.1.2",
+						"bluebird": "^3.5.3",
+						"find-npm-prefix": "^1.0.2",
+						"libnpmaccess": "^3.0.1",
+						"libnpmconfig": "^1.2.1",
+						"libnpmhook": "^5.0.2",
+						"libnpmorg": "^1.0.0",
+						"libnpmpublish": "^1.1.0",
+						"libnpmsearch": "^2.0.0",
+						"libnpmteam": "^1.0.1",
+						"lock-verify": "^2.0.2",
+						"npm-lifecycle": "^2.1.0",
+						"npm-logical-tree": "^1.2.1",
+						"npm-package-arg": "^6.1.0",
+						"npm-profile": "^4.0.1",
+						"npm-registry-fetch": "^3.8.0",
+						"npmlog": "^4.1.2",
+						"pacote": "^9.2.3",
+						"read-package-json": "^2.0.13",
+						"stringify-package": "^1.0.0"
+					}
+				},
+				"libnpmaccess": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"get-stream": "^4.0.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^3.8.0"
 					},
 					"dependencies": {
-						"npm-registry-fetch": {
-							"version": "3.1.1",
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmconfig": {
+					"version": "1.2.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"find-up": "^3.0.0",
+						"ini": "^1.3.5"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "3.0.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"bluebird": "^3.5.1",
-								"figgy-pudding": "^3.1.0",
-								"lru-cache": "^4.1.2",
-								"make-fetch-happen": "^4.0.0",
-								"npm-package-arg": "^6.0.0"
+								"locate-path": "^3.0.0"
 							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"p-limit": {
+							"version": "2.1.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-try": "^2.0.0"
+							}
+						},
+						"p-locate": {
+							"version": "3.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						},
+						"p-try": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmhook": {
+					"version": "5.0.2",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					}
+				},
+				"libnpmorg": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"libnpmpublish": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"lodash.clonedeep": "^4.5.0",
+						"normalize-package-data": "^2.4.0",
+						"npm-package-arg": "^6.1.0",
+						"npm-registry-fetch": "^3.8.0",
+						"semver": "^5.5.1",
+						"ssri": "^6.0.1"
+					}
+				},
+				"libnpmsearch": {
+					"version": "2.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					}
+				},
+				"libnpmteam": {
+					"version": "1.0.1",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"figgy-pudding": "^3.4.1",
+						"get-stream": "^4.0.0",
+						"npm-registry-fetch": "^3.8.0"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
 						}
 					}
 				},
@@ -6622,11 +6999,11 @@
 					}
 				},
 				"lock-verify": {
-					"version": "2.0.2",
+					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"npm-package-arg": "^5.1.2 || 6",
+						"npm-package-arg": "^6.1.0",
 						"semver": "^5.4.1"
 					}
 				},
@@ -6716,7 +7093,7 @@
 					"dev": true
 				},
 				"lru-cache": {
-					"version": "4.1.3",
+					"version": "4.1.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -6854,6 +7231,13 @@
 						"mkdirp": "^0.5.1",
 						"rimraf": "^2.5.4",
 						"run-queue": "^1.0.3"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ms": {
@@ -6930,18 +7314,28 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "2.4.0",
+					"version": "2.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^2.1.4",
-						"is-builtin-module": "^1.0.0",
+						"resolve": "^1.10.0",
 						"semver": "2 || 3 || 4 || 5",
 						"validate-npm-package-license": "^3.0.1"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.10.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"path-parse": "^1.0.6"
+							}
+						}
 					}
 				},
 				"npm-audit-report": {
-					"version": "1.3.1",
+					"version": "1.3.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -6950,7 +7344,7 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.5",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -6999,7 +7393,7 @@
 					}
 				},
 				"npm-packlist": {
-					"version": "1.1.12",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7008,172 +7402,36 @@
 					}
 				},
 				"npm-pick-manifest": {
-					"version": "2.1.0",
+					"version": "2.2.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"figgy-pudding": "^3.5.1",
 						"npm-package-arg": "^6.0.0",
 						"semver": "^5.4.1"
 					}
 				},
 				"npm-profile": {
-					"version": "3.0.2",
+					"version": "4.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.2 || 2",
-						"make-fetch-happen": "^2.5.0 || 3 || 4"
-					}
-				},
-				"npm-registry-client": {
-					"version": "8.6.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"concat-stream": "^1.5.2",
-						"graceful-fs": "^4.1.6",
-						"normalize-package-data": "~1.0.1 || ^2.0.0",
-						"npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-						"npmlog": "2 || ^3.1.0 || ^4.0.0",
-						"once": "^1.3.3",
-						"request": "^2.74.0",
-						"retry": "^0.10.0",
-						"safe-buffer": "^5.1.1",
-						"semver": "2 >=2.2.1 || 3.x || 4 || 5",
-						"slide": "^1.1.3",
-						"ssri": "^5.2.4"
-					},
-					"dependencies": {
-						"retry": {
-							"version": "0.10.1",
-							"bundled": true,
-							"dev": true
-						},
-						"ssri": {
-							"version": "5.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.1.1"
-							}
-						}
+						"figgy-pudding": "^3.4.1",
+						"npm-registry-fetch": "^3.8.0"
 					}
 				},
 				"npm-registry-fetch": {
-					"version": "1.1.0",
+					"version": "3.9.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"JSONStream": "^1.3.4",
 						"bluebird": "^3.5.1",
-						"figgy-pudding": "^2.0.1",
-						"lru-cache": "^4.1.2",
-						"make-fetch-happen": "^3.0.0",
-						"npm-package-arg": "^6.0.0",
-						"safe-buffer": "^5.1.1"
-					},
-					"dependencies": {
-						"cacache": {
-							"version": "10.0.4",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"bluebird": "^3.5.1",
-								"chownr": "^1.0.1",
-								"glob": "^7.1.2",
-								"graceful-fs": "^4.1.11",
-								"lru-cache": "^4.1.1",
-								"mississippi": "^2.0.0",
-								"mkdirp": "^0.5.1",
-								"move-concurrently": "^1.0.1",
-								"promise-inflight": "^1.0.1",
-								"rimraf": "^2.6.2",
-								"ssri": "^5.2.4",
-								"unique-filename": "^1.1.0",
-								"y18n": "^4.0.0"
-							},
-							"dependencies": {
-								"mississippi": {
-									"version": "2.0.0",
-									"bundled": true,
-									"dev": true,
-									"requires": {
-										"concat-stream": "^1.5.0",
-										"duplexify": "^3.4.2",
-										"end-of-stream": "^1.1.0",
-										"flush-write-stream": "^1.0.0",
-										"from2": "^2.1.0",
-										"parallel-transform": "^1.1.0",
-										"pump": "^2.0.1",
-										"pumpify": "^1.3.3",
-										"stream-each": "^1.1.0",
-										"through2": "^2.0.0"
-									}
-								}
-							}
-						},
-						"figgy-pudding": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true
-						},
-						"make-fetch-happen": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"agentkeepalive": "^3.4.1",
-								"cacache": "^10.0.4",
-								"http-cache-semantics": "^3.8.1",
-								"http-proxy-agent": "^2.1.0",
-								"https-proxy-agent": "^2.2.0",
-								"lru-cache": "^4.1.2",
-								"mississippi": "^3.0.0",
-								"node-fetch-npm": "^2.0.2",
-								"promise-retry": "^1.1.1",
-								"socks-proxy-agent": "^3.0.1",
-								"ssri": "^5.2.4"
-							}
-						},
-						"pump": {
-							"version": "2.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"end-of-stream": "^1.1.0",
-								"once": "^1.3.1"
-							}
-						},
-						"smart-buffer": {
-							"version": "1.1.15",
-							"bundled": true,
-							"dev": true
-						},
-						"socks": {
-							"version": "1.1.10",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ip": "^1.1.4",
-								"smart-buffer": "^1.0.13"
-							}
-						},
-						"socks-proxy-agent": {
-							"version": "3.0.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"agent-base": "^4.1.0",
-								"socks": "^1.1.10"
-							}
-						},
-						"ssri": {
-							"version": "5.3.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"safe-buffer": "^5.1.1"
-							}
-						}
+						"figgy-pudding": "^3.4.1",
+						"lru-cache": "^4.1.3",
+						"make-fetch-happen": "^4.0.1",
+						"npm-package-arg": "^6.1.0"
 					}
 				},
 				"npm-run-path": {
@@ -7295,35 +7553,61 @@
 					}
 				},
 				"pacote": {
-					"version": "8.1.6",
+					"version": "9.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"bluebird": "^3.5.1",
-						"cacache": "^11.0.2",
-						"get-stream": "^3.0.0",
-						"glob": "^7.1.2",
-						"lru-cache": "^4.1.3",
+						"bluebird": "^3.5.3",
+						"cacache": "^11.3.2",
+						"figgy-pudding": "^3.5.1",
+						"get-stream": "^4.1.0",
+						"glob": "^7.1.3",
+						"lru-cache": "^5.1.1",
 						"make-fetch-happen": "^4.0.1",
 						"minimatch": "^3.0.4",
-						"minipass": "^2.3.3",
+						"minipass": "^2.3.5",
 						"mississippi": "^3.0.0",
 						"mkdirp": "^0.5.1",
 						"normalize-package-data": "^2.4.0",
 						"npm-package-arg": "^6.1.0",
-						"npm-packlist": "^1.1.10",
-						"npm-pick-manifest": "^2.1.0",
+						"npm-packlist": "^1.1.12",
+						"npm-pick-manifest": "^2.2.3",
+						"npm-registry-fetch": "^3.8.0",
 						"osenv": "^0.1.5",
 						"promise-inflight": "^1.0.1",
 						"promise-retry": "^1.1.1",
-						"protoduck": "^5.0.0",
+						"protoduck": "^5.0.1",
 						"rimraf": "^2.6.2",
 						"safe-buffer": "^5.1.2",
-						"semver": "^5.5.0",
-						"ssri": "^6.0.0",
-						"tar": "^4.4.3",
-						"unique-filename": "^1.1.0",
-						"which": "^1.3.0"
+						"semver": "^5.6.0",
+						"ssri": "^6.0.1",
+						"tar": "^4.4.8",
+						"unique-filename": "^1.1.1",
+						"which": "^1.3.1"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "5.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"yallist": "^3.0.2"
+							}
+						},
+						"minipass": {
+							"version": "2.3.5",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "^5.1.2",
+								"yallist": "^3.0.0"
+							}
+						},
+						"yallist": {
+							"version": "3.0.3",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"parallel-transform": {
@@ -7334,6 +7618,30 @@
 						"cyclist": "~0.2.2",
 						"inherits": "^2.0.3",
 						"readable-stream": "^2.1.5"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"path-exists": {
@@ -7353,6 +7661,11 @@
 				},
 				"path-key": {
 					"version": "2.0.1",
+					"bundled": true,
+					"dev": true
+				},
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -7411,11 +7724,11 @@
 					"dev": true
 				},
 				"protoduck": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"genfun": "^4.0.1"
+						"genfun": "^5.0.0"
 					}
 				},
 				"prr": {
@@ -7479,7 +7792,7 @@
 					"dev": true
 				},
 				"query-string": {
-					"version": "6.1.0",
+					"version": "6.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7553,7 +7866,7 @@
 					}
 				},
 				"read-package-tree": {
-					"version": "5.2.1",
+					"version": "5.2.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -7565,17 +7878,13 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.6",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"readdir-scoped-modules": {
@@ -7654,11 +7963,11 @@
 					"dev": true
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"run-queue": {
@@ -7667,6 +7976,13 @@
 					"dev": true,
 					"requires": {
 						"aproba": "^1.1.1"
+					},
+					"dependencies": {
+						"aproba": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"safe-buffer": {
@@ -7680,7 +7996,7 @@
 					"dev": true
 				},
 				"semver": {
-					"version": "5.5.1",
+					"version": "5.6.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -7704,6 +8020,30 @@
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"readable-stream": "^2.0.2"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"shebang-command": {
@@ -7827,7 +8167,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.0",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true
 				},
@@ -7871,6 +8211,30 @@
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"stream-shift": "^1.0.0"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"stream-shift": {
@@ -7913,7 +8277,7 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8011,6 +8375,30 @@
 					"requires": {
 						"readable-stream": "^2.1.5",
 						"xtend": "~4.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.6",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						},
+						"string_decoder": {
+							"version": "1.1.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"safe-buffer": "~5.1.0"
+							}
+						}
 					}
 				},
 				"timed-out": {
@@ -8062,7 +8450,7 @@
 					"dev": true
 				},
 				"unique-filename": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8246,7 +8634,7 @@
 					"dev": true
 				},
 				"write-file-atomic": {
-					"version": "2.3.0",
+					"version": "2.4.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -8536,12 +8924,12 @@
 			}
 		},
 		"os-name": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
-			"integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+			"integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
 			"dev": true,
 			"requires": {
-				"macos-release": "^2.0.0",
+				"macos-release": "^2.2.0",
 				"windows-release": "^3.1.0"
 			}
 		},
@@ -8573,9 +8961,9 @@
 			"dev": true
 		},
 		"p-is-promise": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-			"integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true
 		},
 		"p-limit": {
@@ -9277,9 +9665,9 @@
 			"dev": true
 		},
 		"semantic-release": {
-			"version": "15.13.4",
-			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.4.tgz",
-			"integrity": "sha512-z7NdRqW084HVlVFaso1aWJKwWly6ZhqtSmCuQNXo5XR2KHWSqQJrRrZiksCga+0lxQgsNaKp3R5xkcpVpC4ZKQ==",
+			"version": "15.13.9",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-15.13.9.tgz",
+			"integrity": "sha512-EKm23KsIAfq1P9dMx8y7YmMHvWZRvmEEUE7z9FXQy2iY1k4jeeRYJTab1aykbYJ1Vj2p9mtkPo59Yi7YVsPUdw==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/commit-analyzer": "^6.1.0",
@@ -9294,16 +9682,16 @@
 				"execa": "^1.0.0",
 				"figures": "^2.0.0",
 				"find-versions": "^3.0.0",
-				"get-stream": "^4.0.0",
+				"get-stream": "^5.0.0",
 				"git-log-parser": "^1.2.0",
-				"hook-std": "^1.1.0",
+				"hook-std": "^2.0.0",
 				"hosted-git-info": "^2.7.1",
 				"lodash": "^4.17.4",
 				"marked": "^0.6.0",
 				"marked-terminal": "^3.2.0",
-				"p-locate": "^3.0.0",
-				"p-reduce": "^1.0.0",
-				"read-pkg-up": "^4.0.0",
+				"p-locate": "^4.0.0",
+				"p-reduce": "^2.0.0",
+				"read-pkg-up": "^5.0.0",
 				"resolve-from": "^4.0.0",
 				"semver": "^5.4.1",
 				"signale": "^1.2.1",
@@ -9345,6 +9733,17 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+							"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+							"dev": true,
+							"requires": {
+								"pump": "^3.0.0"
+							}
+						}
 					}
 				},
 				"find-up": {
@@ -9357,9 +9756,9 @@
 					}
 				},
 				"get-stream": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -9379,34 +9778,61 @@
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
+					},
+					"dependencies": {
+						"p-locate": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+							"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+							"dev": true,
+							"requires": {
+								"p-limit": "^2.0.0"
+							}
+						}
 					}
 				},
 				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 					"dev": true,
 					"requires": {
-						"p-limit": "^2.0.0"
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-reduce": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+					"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+					"dev": true
+				},
+				"read-pkg": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.0.0.tgz",
+					"integrity": "sha512-OWufaRc67oJjcgrxckW/qO9q22iYzyiONh8h+GMcnOvSHAmhV1Dr3x+gyRjP+Qxc5jKupkSfoCQLS/98rDPh9A==",
+					"dev": true,
+					"requires": {
+						"normalize-package-data": "^2.3.2",
+						"parse-json": "^4.0.0"
 					}
 				},
 				"read-pkg-up": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-					"integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+					"integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
 					"dev": true,
 					"requires": {
 						"find-up": "^3.0.0",
-						"read-pkg": "^3.0.0"
+						"read-pkg": "^5.0.0"
 					}
 				},
 				"resolve-from": {
@@ -9493,9 +9919,9 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"signale": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/signale/-/signale-1.3.0.tgz",
-			"integrity": "sha512-TyFhsQ9wZDYDfsPqWMyjCxsDoMwfpsT0130Mce7wDiVCSDdtWSg83dOqoj8aGpGCs3n1YPcam6sT1OFPuGT/OQ==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+			"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.3.2",
@@ -10098,13 +10524,13 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+			"integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.17.1",
+				"commander": "~2.20.0",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
@@ -10411,12 +10837,12 @@
 			}
 		},
 		"windows-release": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
-			"integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+			"integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.10.0"
+				"execa": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -10433,18 +10859,27 @@
 					}
 				},
 				"execa": {
-					"version": "0.10.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-					"integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
-						"get-stream": "^3.0.0",
+						"get-stream": "^4.0.0",
 						"is-stream": "^1.1.0",
 						"npm-run-path": "^2.0.0",
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"dev": true,
+					"requires": {
+						"pump": "^3.0.0"
 					}
 				}
 			}
@@ -10553,9 +10988,9 @@
 			"dev": true
 		},
 		"yargs": {
-			"version": "13.2.1",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.1.tgz",
-			"integrity": "sha512-HgY0xHGmPPakg6kEDufqxZuXVtvPZcipORC8O7S44iEnwsUmP+qnhReHc6d1dyeIZkrPmYFblh45Z2oeDn++fQ==",
+			"version": "13.2.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+			"integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
 			"dev": true,
 			"requires": {
 				"cliui": "^4.0.0",
@@ -10572,9 +11007,9 @@
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-					"integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"find-up": {
@@ -10597,9 +11032,9 @@
 					}
 				},
 				"p-limit": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-					"integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -10615,23 +11050,23 @@
 					}
 				},
 				"string-width": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.0.0.tgz",
-					"integrity": "sha512-rr8CUxBbvOZDUvc5lNIJ+OC1nPVpz+Siw9VBtUjB9b6jZehZLFt0JMCZzShFHIsI8cbhm0EsNIfWJMFV3cu3Ew==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
 						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^5.0.0"
+						"strip-ansi": "^5.1.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-					"integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^4.0.0"
+						"ansi-regex": "^4.1.0"
 					}
 				}
 			}
@@ -10647,9 +11082,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "persistent-cache": "^1.1.1"
   },
   "devDependencies": {
+    "@semantic-release/git": "^7.0.8",
+    "@semantic-release/npm": "^5.1.4",
     "ava": "^1.0.1",
     "cz-conventional-changelog": "^2.1.0",
     "git-cz": "^1.8.0",
@@ -66,7 +68,6 @@
       "url": "burntfen.com"
     }
   ],
-  "main": "src/index.js",
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"

--- a/package.json
+++ b/package.json
@@ -45,11 +45,11 @@
   },
   "devDependencies": {
     "@semantic-release/git": "^7.0.8",
-    "@semantic-release/npm": "^5.1.4",
+    "@semantic-release/npm": "^5.1.7",
     "ava": "^1.0.1",
     "cz-conventional-changelog": "^2.1.0",
     "git-cz": "^1.8.0",
-    "semantic-release": "^15.13.4",
+    "semantic-release": "^15.13.9",
     "standard": "^12.0.1"
   },
   "engines": {


### PR DESCRIPTION
After noticing `v3.4.0` and below had change-logs on the GitHub releases and not the later versions (which I guess was due to the previous issues with TravisCI+SR, which caught my attention after waiting for a release to be visible on the repo). I thought it was a good idea to get the plugins I found useful for some of my projects and which I guess was used here before.