### PR TITLE
fix: rate limit detection

### DIFF
--- a/src/graphql.js
+++ b/src/graphql.js
@@ -420,9 +420,8 @@ const abusive = e => {
 }
 
 const rateLimited = e => {
-  const body = JSON.parse(e.body)
   const rem = e && e.headers && e.headers['x-ratelimit-remaining']
-  return e.status === 200 && body.data === null && rem && parseInt(rem) === 0
+  return rem && parseInt(rem) === 0
 }
 
 const untilReset = e => {


### PR DESCRIPTION
`body` is not null. In my experience I got:

```json
body: '{"data":{"rateLimit":{"cost":1,"remaining":0,"resetAt":"2019-08-05T12:01:30Z"},"node":{"comments":{"pageInfo":{"endCursor"...
```

I'm not certain why it would need to be `null` and why inspection of the header wouldn't suffice.

`status` check is also unnecessary, `queryRequest` rejects for non-200 responses so `rateLimited` will not be called in this case.